### PR TITLE
Modification so "starting fixture" line is not printed if we are getting...

### DIFF
--- a/src/main/java/org/concordion/internal/CachedRunResults.java
+++ b/src/main/java/org/concordion/internal/CachedRunResults.java
@@ -6,14 +6,27 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.concordion.api.Result;
 import org.concordion.api.ResultSummary;
 
+/**
+ *
+ * A thread-safe class to provide caching of run results.
+ *
+ * @author Tim Wright <tim@tfwright.co.nz>
+ *
+ */
 public class CachedRunResults {
 
+    /**
+     * Basic status of a cache entry
+     */
     private enum RunStatus {
         NOT_STARTED,
         RUNNING,
         FINISHED
     }
 
+    /**
+     * Data to store in the cache
+     */
     private class CachedRunSummary {
         private RunStatus status;
         private ResultSummary resultSummary;
@@ -27,26 +40,43 @@ public class CachedRunResults {
 
 	Map<Class<?>, CachedRunSummary> map = new ConcurrentHashMap<Class<?>, CachedRunSummary>();
 
+    /**
+     * Searches for a match in the cache. If there is no match, it marks the test as "in progress".
+     * This is done in one method to avoid thread synchronization issues
+     *
+     * @param fixtureClass the class to retrieve
+     * @return the result summary from the cache
+     */
     public synchronized ResultSummary startRun(Class<? extends Object> fixtureClass) {
 
-
+        // check to see if there is a result in the cache
         CachedRunSummary runSummary = map.get(fixtureClass);
         if (runSummary != null) {
             return runSummary.resultSummary;
         }
 
-        System.err.println("Starting fixture for class" + fixtureClass.getName());
-
+        // no cached result, so update the cache with a "running" state - that means we can detect circular dependancies
         runSummary = new CachedRunSummary(RunStatus.RUNNING, fixtureClass);
         map.put(fixtureClass, runSummary);
         return null;
     }
 
+    /**
+     * Updates the cache with the results of a run
+     *
+     * @param fixtureClass the class to update
+     * @param resultSummary the results
+     */
     public synchronized void finishRun(Class<?> fixtureClass, ResultSummary resultSummary) {
+        // check if there is already a result
         CachedRunSummary runSummary = map.get(fixtureClass);
         if (runSummary == null) {
+            // no result? Create one. This should never happen because startRun should always be called before
+            // finishRun
             runSummary = new CachedRunSummary(RunStatus.FINISHED, fixtureClass);
         }
+
+        // update the cache
         runSummary.status = RunStatus.FINISHED;
         runSummary.resultSummary = resultSummary;
 


### PR DESCRIPTION
... results from the cache.
