### PR TITLE
Added support for the JUnit Rule annotation

### DIFF
--- a/src/test-dummies/java/spec/concordion/results/runTotals/Annotations.java
+++ b/src/test-dummies/java/spec/concordion/results/runTotals/Annotations.java
@@ -1,0 +1,62 @@
+package spec.concordion.results.runTotals;
+
+import org.concordion.integration.junit4.ConcordionRunner;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.Statement;
+
+/**
+ * Created by tim on 20/06/15.
+ */
+@RunWith(ConcordionRunner.class)
+public class Annotations {
+
+    private static boolean beforeClassCalled=false;
+    private boolean beforeCalled=false;
+    private boolean ruleMethodInvoked = false;
+    private boolean ruleFieldInvoked = false;
+
+    @Before
+    public void before() {
+        beforeCalled = true;
+    }
+    @BeforeClass
+    public static void beforeClass() {
+        beforeClassCalled = true;
+    }
+
+    @Rule
+    public TestRule rule = new RuleWithCallback(new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+            Annotations.this.ruleFieldInvoked = true;
+        }
+    });
+
+    @Rule
+    public TestRule ruleMethod() {
+        return new RuleWithCallback(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Annotations.this.ruleMethodInvoked = true;
+            }
+        });
+    }
+
+
+    public boolean wasBeforeCalled() {
+        return beforeCalled;
+    }
+    public boolean wasBeforeClassCalled() {
+        return beforeClassCalled;
+    }
+    public boolean wasRuleMethodInvoked() {
+        return ruleMethodInvoked;
+    }
+    public boolean wasRuleFieldInvoked() {
+        return ruleFieldInvoked;
+    }
+}

--- a/src/test-dummies/java/spec/concordion/results/runTotals/CompoundStatement.java
+++ b/src/test-dummies/java/spec/concordion/results/runTotals/CompoundStatement.java
@@ -1,0 +1,22 @@
+package spec.concordion.results.runTotals;
+
+import org.junit.runners.model.Statement;
+
+/**
+ * Created by tim on 20/06/15.
+ */
+class CompoundStatement extends Statement {
+    Statement statement1;
+    Statement statement2;
+
+    public CompoundStatement(Statement statement1, Statement statement2) {
+        this.statement1 = statement1;
+        this.statement2 = statement2;
+    }
+
+    @Override
+    public void evaluate() throws Throwable {
+        statement1.evaluate();
+        statement2.evaluate();
+    }
+}

--- a/src/test-dummies/java/spec/concordion/results/runTotals/RuleWithCallback.java
+++ b/src/test-dummies/java/spec/concordion/results/runTotals/RuleWithCallback.java
@@ -1,0 +1,23 @@
+package spec.concordion.results.runTotals;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Created by tim on 20/06/15.
+ */
+class RuleWithCallback implements TestRule {
+    private final Statement callback;
+
+    public RuleWithCallback(Statement callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        // pass the callback object first.
+        return new CompoundStatement(callback, base);
+    }
+
+}

--- a/src/test-dummies/resources/spec/concordion/results/runTotals/Annotations.html
+++ b/src/test-dummies/resources/spec/concordion/results/runTotals/Annotations.html
@@ -1,0 +1,15 @@
+<html xmlns:concordion="http://www.concordion.org/2007/concordion">
+<link href="../../../../concordion.css" rel="stylesheet" type="text/css" />
+<body>
+
+<h1>JUnit 4 Annotations</h1>
+
+<div>
+The JUnit 4 integration supports the <span concordion:assertTrue="wasBeforeCalled()">Before</span>,
+<span concordion:assertTrue="wasBeforeClassCalled()">BeforeClass</span>,
+    <span concordion:assertTrue="wasRuleMethodInvoked()">Rule</span> method annotations, and
+    <span concordion:assertTrue="wasRuleFieldInvoked()">Rule</span> field annotations.
+</div>
+
+</body>
+</html>

--- a/src/test/java/spec/concordion/integration/junit4/CompoundStatement.java
+++ b/src/test/java/spec/concordion/integration/junit4/CompoundStatement.java
@@ -1,0 +1,22 @@
+package spec.concordion.integration.junit4;
+
+import org.junit.runners.model.Statement;
+
+/**
+ * Created by tim on 20/06/15.
+ */
+class CompoundStatement extends Statement {
+    Statement statement1;
+    Statement statement2;
+
+    public CompoundStatement(Statement statement1, Statement statement2) {
+        this.statement1 = statement1;
+        this.statement2 = statement2;
+    }
+
+    @Override
+    public void evaluate() throws Throwable {
+        statement1.evaluate();
+        statement2.evaluate();
+    }
+}

--- a/src/test/java/spec/concordion/integration/junit4/Junit4Test.java
+++ b/src/test/java/spec/concordion/integration/junit4/Junit4Test.java
@@ -1,0 +1,48 @@
+package spec.concordion.integration.junit4;
+
+import org.concordion.integration.junit4.ConcordionRunner;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.Statement;
+
+/**
+ * Created by tim on 20/06/15.
+ */
+@RunWith(ConcordionRunner.class)
+public class Junit4Test extends Statement {
+
+    private static boolean beforeClassCalled=false;
+    private boolean beforeCalled=false;
+    private boolean ruleInvoked = false;
+
+    @Before
+    public void before() {
+        beforeCalled = true;
+    }
+    @BeforeClass
+    public static void beforeClass() {
+        beforeClassCalled = true;
+    }
+
+    @Rule
+    public TestRule rule = new RuleWithCallback(this);
+
+    @Override
+    public void evaluate() throws Throwable {
+        ruleInvoked = true;
+    }
+
+
+    public boolean wasBeforeCalled() {
+        return beforeCalled;
+    }
+    public boolean wasBeforeClassCalled() {
+        return beforeClassCalled;
+    }
+    public boolean wasRuleInvoked() {
+        return ruleInvoked;
+    }
+}

--- a/src/test/java/spec/concordion/integration/junit4/RuleWithCallback.java
+++ b/src/test/java/spec/concordion/integration/junit4/RuleWithCallback.java
@@ -1,0 +1,23 @@
+package spec.concordion.integration.junit4;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Created by tim on 20/06/15.
+ */
+class RuleWithCallback implements TestRule {
+    private final Statement callback;
+
+    public RuleWithCallback(Statement callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        // pass the callback object first.
+        return new CompoundStatement(callback, base);
+    }
+
+}

--- a/src/test/java/spec/concordion/integration/junit4/RulesSupportedByJunit.java
+++ b/src/test/java/spec/concordion/integration/junit4/RulesSupportedByJunit.java
@@ -1,0 +1,27 @@
+package spec.concordion.integration.junit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by tim on 20/06/15.
+ */
+public class RulesSupportedByJunit extends Statement {
+
+    @Rule
+    public RuleWithCallback rule = new RuleWithCallback(this);
+    private boolean ruleInvoked = false;
+
+    @Test
+    public void something() {
+        assertTrue(ruleInvoked);
+    }
+
+    @Override
+    public void evaluate() throws Throwable {
+        ruleInvoked = true;
+    }
+}

--- a/src/test/resources/spec/concordion/command/run/Run.html
+++ b/src/test/resources/spec/concordion/command/run/Run.html
@@ -34,7 +34,7 @@
 <pre>
 &lt;a concordion:run="concordion" href="../set/Set.html"&gt;set command&lt;/a&gt;</pre>
         
-    </div>        
+    </div>
 
     <h2>Further Details</h2>
 

--- a/src/test/resources/spec/concordion/integration/junit4/Junit4.html
+++ b/src/test/resources/spec/concordion/integration/junit4/Junit4.html
@@ -1,0 +1,33 @@
+<html xmlns:concordion="http://www.concordion.org/2007/concordion">
+<link href="../../../../concordion.css" rel="stylesheet" type="text/css" />
+<body>
+
+<h1>JUnit 4</h1>
+
+<p>
+    An active specification with JUnit 4 consists of two parts: an
+    HTML file and a Java test that extends <code>ConcordionTestCase</code>.
+</p>
+
+<p>
+    When you run the test class using JUnit, it will automatically locate
+    the HTML file. It does this by looking in the same package for a ".html"
+    file named the same as the test, but without the "Test" suffix.
+</p>
+
+<div class="example">
+    <h3>Example</h3>
+
+    <p>
+        If your test is called <b>com.example.BreadcrumbTest</b> then the corresponding
+        HTML file must be in the same package (<b>com.example</b>) and called
+        <b>Breadcrumb.html</b>.
+    </p>
+</div>
+
+The JUnit 4 integration supports the <span concordion:assertTrue="wasBeforeCalled()">Before</span>,
+<span concordion:assertTrue="wasBeforeClassCalled()">BeforeClass</span>,
+and <span concordion:assertTrue="wasRuleInvoked()">Rule</span> annotations.
+
+</body>
+</html>

--- a/src/test/resources/spec/concordion/results/runTotals/RunTotals.html
+++ b/src/test/resources/spec/concordion/results/runTotals/RunTotals.html
@@ -21,7 +21,7 @@
 			<th concordion:assertEquals="#result.ignoredCount">Ignored</th>
 			<th concordion:assertEquals="#result.totalsString">Totals String</th>
 		</tr>
-	
+
 	  	<tr>
 	  		<td>JUnit 3 test class that has multiple successful tests in it.</td>
 			<td><a href="JUnit3RunTotals.html">JUnit3RunTotals.html</a></td>
@@ -42,16 +42,6 @@
 			<td>Successes: 2, Failures: 0</td>
 		</tr>
 
-		<!-- <tr>
-			<td>Test bad HTML</td>
-			<td><a href="BadHtml.html">BadHtml.html</a></td>
-			<td>0</td>
-			<td>0</td>
-			<td>1</td>
-			<td>0</td>
-			<td>Successes: 0, Failures: 0, Exceptions: 1</td>
-		</tr> -->
-
 		<tr>
 			<td>Test missing HTML</td>
 			<td><a href="NoHtml.html">NoHtml.html</a></td>
@@ -60,7 +50,7 @@
 			<td>1</td>
 			<td>0</td>
 			<td>Successes: 0, Failures: 0, Exceptions: 1</td>
-		</tr> 
+		</tr>
 
 		<tr>
 			<td>Test a fixture that returns a mixture of successes, failures, and exceptions</td>
@@ -70,7 +60,7 @@
 			<td>1</td>
 			<td>0</td>
 			<td>Successes: 3, Failures: 2, Exceptions: 1</td>
-		</tr> 
+		</tr>
 
 	 	<tr>
 	 		<td>Test a test with a jUit "ignore" annotation </td>
@@ -122,8 +112,18 @@
 			<td>Successes: 7, Failures: 2, Ignored: 3, Exceptions: 3</td>
 		</tr>
 
+		<tr>
+			<td>Test that the JUnit annotations work when performing a concordion:run command</td>
+			<td><a href="Annotations.html">Annotations.html</a></td>
+			<td>4</td>
+			<td>0</td>
+			<td>0</td>
+			<td>0</td>
+			<td>Successes: 4, Failures: 0</td>
+		</tr>
 
-	
+
+
 	</table>
 	
 


### PR DESCRIPTION
On fields and methods when using the concordion:run command. It already worked in concordion tests when run "normally" by junit. I've got it working for the TestRule class but not the depreciated MethodRule class.