### PR TITLE
Add file:/// to path of specification in output

### DIFF
--- a/src/main/java/org/concordion/internal/FileTarget.java
+++ b/src/main/java/org/concordion/internal/FileTarget.java
@@ -87,6 +87,6 @@ public class FileTarget implements Target {
     }
     
     public String resolvedPathFor(Resource resource) {
-        return getFile(resource).getAbsolutePath();
+        return "file://" + getFile(resource).getAbsolutePath();
     }
 }


### PR DESCRIPTION
With the new example command in Concordion 2.0, the specification name in the output contains a link to the specific example, for example: 
 
`/path/to/my/specification.html#Example1`

When pasted into a browser URL bar, the `#` is turned into a `%23` and the page is not found (tested with Firefox and Chrome).

By prefixing `file://` to the link, the link can be pasted into the browser URL bar and the page is found, for example:

`file:///path/to/my/specification.html#Example1`

/cc @drtimwright 