### PR TITLE
Reuse Patterns in SimpleEvaluator

### DIFF
--- a/src/main/java/org/concordion/internal/MultiPattern.java
+++ b/src/main/java/org/concordion/internal/MultiPattern.java
@@ -1,0 +1,32 @@
+package org.concordion.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class MultiPattern {
+
+    private final List<Pattern> patterns;
+
+    private MultiPattern(List<Pattern> patterns) {
+        this.patterns = Collections.unmodifiableList(patterns);
+    }
+
+    public boolean matches(String input) {
+        for (Pattern pattern : patterns) {
+            if (pattern.matcher(input).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static MultiPattern fromRegularExpressions(String... regularExpressions) {
+        List<Pattern> patterns = new ArrayList<Pattern>(regularExpressions.length);
+        for (String regularExpression : regularExpressions) {
+            patterns.add(Pattern.compile(regularExpression));
+        }
+        return new MultiPattern(patterns);
+    }
+}

--- a/src/main/java/org/concordion/internal/SimpleEvaluator.java
+++ b/src/main/java/org/concordion/internal/SimpleEvaluator.java
@@ -1,8 +1,5 @@
 package org.concordion.internal;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class SimpleEvaluator extends OgnlEvaluator {
 
     public SimpleEvaluator(Object fixture) {
@@ -21,65 +18,53 @@ public class SimpleEvaluator extends OgnlEvaluator {
         super.setVariable(expression, value);
     }
 
-    private static String METHOD_NAME_PATTERN = "[a-z][a-zA-Z0-9_]*";
-    private static String PROPERTY_NAME_PATTERN = "[a-z][a-zA-Z0-9_]*";
-    private static String STRING_PATTERN = "'[^']+'";
-    private static String LHS_VARIABLE_PATTERN = "#" + METHOD_NAME_PATTERN;
-    private static String RHS_VARIABLE_PATTERN = "(" + LHS_VARIABLE_PATTERN + "|#TEXT|#HREF|#LEVEL)";
-    
+
     public static void validateEvaluationExpression(String expression) {
-        
-        // Examples of possible expressions in test.concordion.internal.ExpressionTest
-        
-        String METHOD_CALL_PARAMS = METHOD_NAME_PATTERN + " *\\( *" + RHS_VARIABLE_PATTERN + "(, *" + RHS_VARIABLE_PATTERN + " *)*\\)";
-        String METHOD_CALL_NO_PARAMS = METHOD_NAME_PATTERN + " *\\( *\\)";
-        String TERNARY_STRING_RESULT = " \\? " + STRING_PATTERN + " : " + STRING_PATTERN;
-        
-        List<String> regexs = new ArrayList<String>();
-        regexs.add(PROPERTY_NAME_PATTERN);
-        regexs.add(METHOD_CALL_NO_PARAMS);
-        regexs.add(METHOD_CALL_PARAMS);
-        regexs.add(RHS_VARIABLE_PATTERN);
-        regexs.add(LHS_VARIABLE_PATTERN + "(\\." + PROPERTY_NAME_PATTERN +  ")+");
-        regexs.add(LHS_VARIABLE_PATTERN + " *= *" + PROPERTY_NAME_PATTERN);
-        regexs.add(LHS_VARIABLE_PATTERN + " *= *" + METHOD_CALL_NO_PARAMS);
-        regexs.add(LHS_VARIABLE_PATTERN + " *= *" + METHOD_CALL_PARAMS);
-        regexs.add(LHS_VARIABLE_PATTERN + TERNARY_STRING_RESULT);
-        regexs.add(PROPERTY_NAME_PATTERN + TERNARY_STRING_RESULT);
-        regexs.add(METHOD_CALL_NO_PARAMS + TERNARY_STRING_RESULT);
-        regexs.add(METHOD_CALL_PARAMS + TERNARY_STRING_RESULT);
-        regexs.add(LHS_VARIABLE_PATTERN + "\\." + METHOD_CALL_NO_PARAMS);
-        regexs.add(LHS_VARIABLE_PATTERN + "\\." + METHOD_CALL_PARAMS);
-        
-        expression = expression.trim();
-        for (String regex : regexs) {
-            if (expression.matches(regex)) {
-                return;
-            }
+        if (!EVALUATION_PATTERNS.matches(expression)) {
+            throw new RuntimeException("Invalid expression [" + expression + "]");
         }
-        throw new RuntimeException("Invalid expression [" + expression + "]");
     }
 
     public static void validateSetVariableExpression(String expression) {
-        // #var                         VARIABLE
-        // #var = myProp                VARIABLE = PROPERTY
-        // #var = myMethod()            VARIABLE = METHOD
-        // #var = myMethod(var1)        VARIABLE = METHOD_WITH_PARAM
-        // #var = myMethod(var1, var2)  VARIABLE = METHOD_WITH_MULTIPLE_PARAMS
-        
-        List<String> regexs = new ArrayList<String>();
-        regexs.add(RHS_VARIABLE_PATTERN);
-        regexs.add(LHS_VARIABLE_PATTERN + "\\." + PROPERTY_NAME_PATTERN);
-        regexs.add(LHS_VARIABLE_PATTERN + " *= *" + PROPERTY_NAME_PATTERN);
-        regexs.add(LHS_VARIABLE_PATTERN + " *= *" + METHOD_NAME_PATTERN + " *\\( *\\)");
-        regexs.add(LHS_VARIABLE_PATTERN + " *= *" + METHOD_NAME_PATTERN + " *\\( *" + RHS_VARIABLE_PATTERN + "(, *" + RHS_VARIABLE_PATTERN + " *)*\\)");
-        
-        expression = expression.trim();
-        for (String regex : regexs) {
-            if (expression.matches(regex)) {
-                return;
-            }
+        if (!SET_VARIABLE_PATTERNS.matches(expression)) {
+            throw new RuntimeException("Invalid 'set' expression [" + expression + "]");
         }
-        throw new RuntimeException("Invalid 'set' expression [" + expression + "]");
     }
+
+    private static final String METHOD_NAME_PATTERN = "[a-z][a-zA-Z0-9_]*";
+    private static final String PROPERTY_NAME_PATTERN = "[a-z][a-zA-Z0-9_]*";
+    private static final String STRING_PATTERN = "'[^']+'";
+    private static final String LHS_VARIABLE_PATTERN = "#" + METHOD_NAME_PATTERN;
+    private static final String RHS_VARIABLE_PATTERN = "(" + LHS_VARIABLE_PATTERN + "|#TEXT|#HREF|#LEVEL)";
+    private static final String METHOD_CALL_PARAMS = METHOD_NAME_PATTERN + " *\\( *" + RHS_VARIABLE_PATTERN + "(, *" + RHS_VARIABLE_PATTERN + " *)*\\)";
+    private static final String METHOD_CALL_NO_PARAMS = METHOD_NAME_PATTERN + " *\\( *\\)";
+    private static final String TERNARY_STRING_RESULT = " \\? " + STRING_PATTERN + " : " + STRING_PATTERN;
+
+    private static final MultiPattern EVALUATION_PATTERNS = MultiPattern.fromRegularExpressions(
+            PROPERTY_NAME_PATTERN,
+            METHOD_CALL_NO_PARAMS,
+            METHOD_CALL_PARAMS,
+            RHS_VARIABLE_PATTERN,
+            LHS_VARIABLE_PATTERN + "(\\." + PROPERTY_NAME_PATTERN + ")+",
+            LHS_VARIABLE_PATTERN + " *= *" + PROPERTY_NAME_PATTERN,
+            LHS_VARIABLE_PATTERN + " *= *" + METHOD_CALL_NO_PARAMS,
+            LHS_VARIABLE_PATTERN + " *= *" + METHOD_CALL_PARAMS,
+            LHS_VARIABLE_PATTERN + TERNARY_STRING_RESULT,
+            PROPERTY_NAME_PATTERN + TERNARY_STRING_RESULT,
+            METHOD_CALL_NO_PARAMS + TERNARY_STRING_RESULT,
+            METHOD_CALL_PARAMS + TERNARY_STRING_RESULT,
+            LHS_VARIABLE_PATTERN + "\\." + METHOD_CALL_NO_PARAMS,
+            LHS_VARIABLE_PATTERN + "\\." + METHOD_CALL_PARAMS);
+
+    // #var                         VARIABLE
+    // #var = myProp                VARIABLE = PROPERTY
+    // #var = myMethod()            VARIABLE = METHOD
+    // #var = myMethod(var1)        VARIABLE = METHOD_WITH_PARAM
+    // #var = myMethod(var1, var2)  VARIABLE = METHOD_WITH_MULTIPLE_PARAMS
+    private static final MultiPattern SET_VARIABLE_PATTERNS = MultiPattern.fromRegularExpressions(
+            RHS_VARIABLE_PATTERN,
+            LHS_VARIABLE_PATTERN + "\\." + PROPERTY_NAME_PATTERN,
+            LHS_VARIABLE_PATTERN + " *= *" + PROPERTY_NAME_PATTERN,
+            LHS_VARIABLE_PATTERN + " *= *" + METHOD_NAME_PATTERN + " *\\( *\\)",
+            LHS_VARIABLE_PATTERN + " *= *" + METHOD_NAME_PATTERN + " *\\( *" + RHS_VARIABLE_PATTERN + "(, *" + RHS_VARIABLE_PATTERN + " *)*\\)");
 }

--- a/src/test/java/org/concordion/internal/MultiPatternTest.java
+++ b/src/test/java/org/concordion/internal/MultiPatternTest.java
@@ -1,0 +1,28 @@
+package org.concordion.internal;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MultiPatternTest {
+
+    private MultiPattern testingInstance = MultiPattern.fromRegularExpressions(
+            "[a-z]",
+            "[0-9]"
+    );
+
+    @Test
+    public void testMatchesFirstRegex() {
+        assertTrue(testingInstance.matches("a"));
+    }
+
+    @Test
+    public void testMatchesSecondRegex() {
+        assertTrue(testingInstance.matches("0"));
+    }
+
+    @Test
+    public void testDoesNotMatch() {
+        assertFalse(testingInstance.matches("A"));
+    }
+}


### PR DESCRIPTION
Hello team,

Simple expression validation logic has been refactored.

Previously it was creating list of regular expressions (as strings) each time validateEvaluationExpression() or validateSetVariableExpression() method called. This makes time consuming call Pattern#compile executed each time.

I have refactored this class to use new MultiPattern class that holds list of Patterns.
This compiles reqular expression just once during Pattern#matcher call and then reuse it. This operation is thread safe.

public API remains same, so no impact on other components. 

Please review jmh benchmark of String#matches() vs Pattern#matcher(String)#matches()

[jmh benchmark](https://www.dropbox.com/s/cxkvz8koktfihb4/Precompile_Recompile.zip?dl=0)
[jmh benchmark result on my computer](https://www.dropbox.com/s/gb30az3mx5o1l0j/Precompile_Recompile.png?dl=0)

Cheers,
Ievgen Degtiarenko