### PR TITLE
Fix listener execution order

### DIFF
--- a/src/main/java/org/concordion/Concordion.java
+++ b/src/main/java/org/concordion/Concordion.java
@@ -10,8 +10,8 @@ public class Concordion {
 
     private final EvaluatorFactory evaluatorFactory;
     private final SpecificationReader specificationReader;
-    private final Resource resource;
-    private final SpecificationByExample specification;
+    private Resource resource;
+    private SpecificationByExample specification;
     private Fixture fixture;
 
     public Concordion(SpecificationLocator specificationLocator, SpecificationReader specificationReader, EvaluatorFactory evaluatorFactory, Fixture fixture) throws IOException {
@@ -20,32 +20,40 @@ public class Concordion {
         this.fixture = fixture;
 
         resource = specificationLocator.locateSpecification(fixture);
-        specification = loadSpecificationFromResource(resource);
     }
 
     public ResultSummary process() throws IOException {
         return process(specification, fixture);
     }
 
-    public ResultSummary process(Resource resource, Fixture fixture) throws IOException {
-        return process(loadSpecificationFromResource(resource), fixture);
+    /** For TestRig use only **/
+    public void override(Resource resource, Fixture fixture) throws IOException {
+        this.resource= resource;
+        this.fixture = fixture;
     }
  
-    private ResultSummary process(SpecificationByExample specification, Fixture fixture) {
+    private ResultSummary process(SpecificationByExample specification, Fixture fixture) throws IOException {
         SummarizingResultRecorder resultRecorder = new SummarizingResultRecorder();
         resultRecorder.setSpecificationDescription(fixture.getDescription());
-        specification.process(evaluatorFactory.createEvaluator(fixture.getFixtureObject()), resultRecorder);
+        getSpecification().process(evaluatorFactory.createEvaluator(fixture.getFixtureObject()), resultRecorder);
         return resultRecorder;
     }
 
+    private SpecificationByExample getSpecification() throws IOException {
+        if (specification == null) {
+            specification = loadSpecificationFromResource(resource);
+        }
+        return specification;
+    }
+
     public List<String> getExampleNames() throws IOException {
-        return specification.getExampleNames();
+        return getSpecification().getExampleNames();
     }
 
     public ResultSummary processExample(String example) throws IOException {
         SummarizingResultRecorder resultRecorder = new SummarizingResultRecorder();
         resultRecorder.setSpecificationDescription(example);
-        specification.processExample(evaluatorFactory.createEvaluator(fixture.getFixtureObject()), example, resultRecorder);
+        getSpecification().processExample(evaluatorFactory.createEvaluator(fixture.getFixtureObject()), example, resultRecorder);
         return resultRecorder;
     }
 

--- a/src/main/java/org/concordion/api/AbstractCommand.java
+++ b/src/main/java/org/concordion/api/AbstractCommand.java
@@ -25,7 +25,4 @@ public abstract class AbstractCommand implements Command {
 
     public void executeAsExample(CommandCall commandCall, Evaluator evaluator, ResultRecorder resultRecorder) {
     }
-
-    public void finish(CommandCall commandCall) {
-    }
 }

--- a/src/main/java/org/concordion/api/AbstractCommandDecorator.java
+++ b/src/main/java/org/concordion/api/AbstractCommandDecorator.java
@@ -53,8 +53,4 @@ public abstract class AbstractCommandDecorator implements Command {
     }
 
     protected abstract void process(CommandCall commandCall, Evaluator evaluator, ResultRecorder resultRecorder, Runnable runnable);
-
-    public void finish(CommandCall commandCall) {
-        this.command.finish(commandCall);
-    }
 }

--- a/src/main/java/org/concordion/api/Command.java
+++ b/src/main/java/org/concordion/api/Command.java
@@ -11,8 +11,6 @@ public interface Command {
 
     void verify(CommandCall commandCall, Evaluator evaluator, ResultRecorder resultRecorder);
 
-    void finish(CommandCall commandCall);
-
     List<CommandCall> getExamples(CommandCall command);
 
     boolean isExample();

--- a/src/main/java/org/concordion/api/listener/ExampleEvent.java
+++ b/src/main/java/org/concordion/api/listener/ExampleEvent.java
@@ -7,8 +7,10 @@ public class ExampleEvent {
 
     private final Element element;
     private final ResultSummary resultSummary;
+    private final String exampleName;
 
-    public ExampleEvent(Element element, ResultSummary resultSummary) {
+    public ExampleEvent(String exampleName, Element element, ResultSummary resultSummary) {
+        this.exampleName = exampleName;
         this.resultSummary = resultSummary;
         this.element = element;
     }
@@ -19,5 +21,9 @@ public class ExampleEvent {
 
     public ResultSummary getResultSummary() {
         return resultSummary;
+    }
+
+    public String getExampleName() {
+        return exampleName;
     }
 }

--- a/src/main/java/org/concordion/internal/XMLSpecification.java
+++ b/src/main/java/org/concordion/internal/XMLSpecification.java
@@ -1,6 +1,7 @@
 package org.concordion.internal;
 
 import org.concordion.api.*;
+import org.concordion.internal.command.SpecificationCommand;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,11 +11,18 @@ public class XMLSpecification implements SpecificationByExample {
     private String testDescription;
 
     private final CommandCall rootCommandNode;
+    private final SpecificationCommand specificationCommand;
     private final List<CommandCall> examples;
     private final List<CommandCall> beforeExamples;
 
     public XMLSpecification(CommandCall rootCommandNode) {
         this.rootCommandNode = rootCommandNode;
+        if (!(rootCommandNode.getCommand() instanceof SpecificationCommand)) {
+            throw new IllegalStateException("Expected root command to be a SpecificationCommand");
+        }
+        specificationCommand = (SpecificationCommand) rootCommandNode.getCommand();
+        specificationCommand.start(rootCommandNode);
+
         examples = new ArrayList<CommandCall>();
         beforeExamples = new ArrayList<CommandCall>();
 
@@ -111,6 +119,6 @@ public class XMLSpecification implements SpecificationByExample {
     }
     
     public void finish() {
-    	rootCommandNode.getCommand().finish(rootCommandNode);
+        specificationCommand.finish(rootCommandNode);
     }
 }

--- a/src/main/java/org/concordion/internal/command/ExampleCommand.java
+++ b/src/main/java/org/concordion/internal/command/ExampleCommand.java
@@ -36,17 +36,19 @@ public class ExampleCommand extends AbstractCommand {
     }
 
     public void executeAsExample(CommandCall node, Evaluator evaluator, ResultRecorder resultRecorder) {
-
+        
+        String exampleName = node.getExpression();
+        
         resultRecorder.setSpecificationDescription(
-                specificationDescriber.getDescription(node.getResource(), node.getExpression()));
+                specificationDescriber.getDescription(node.getResource(), exampleName));
 
-        listeners.announce().beforeExample(new ExampleEvent(node.getElement(), (SummarizingResultRecorder)resultRecorder));
+        listeners.announce().beforeExample(new ExampleEvent(exampleName, node.getElement(), (SummarizingResultRecorder)resultRecorder));
         
         try {
             node.getChildren().processSequentially(evaluator, resultRecorder);
             Element aName = new Element("a");
-            aName.addAttribute("name", node.getExpression());
-            aName.addAttribute("id", node.getExpression()); // html5 version
+            aName.addAttribute("name", exampleName);
+            aName.addAttribute("id", exampleName); // html5 version
             node.getElement().prependChild(aName);
 
             String params = node.getParameter("status");
@@ -67,7 +69,7 @@ public class ExampleCommand extends AbstractCommand {
                 node.getElement().prependChild(fixtureNode);
             }
             
-            listeners.announce().afterExample(new ExampleEvent(node.getElement(), (SummarizingResultRecorder)resultRecorder));
+            listeners.announce().afterExample(new ExampleEvent(exampleName, node.getElement(), (SummarizingResultRecorder)resultRecorder));
         } catch (FailFastException e) {
             // Ignore - it'll be re-thrown later if necessary.
         } 

--- a/src/main/java/org/concordion/internal/command/SpecificationCommand.java
+++ b/src/main/java/org/concordion/internal/command/SpecificationCommand.java
@@ -14,8 +14,6 @@ import org.concordion.internal.util.Announcer;
 
 public class SpecificationCommand extends AbstractCommand {
 
-    private boolean specificationExecuted=false;
-
     @Override
     public void setUp(CommandCall commandCall, Evaluator evaluator, ResultRecorder resultRecorder) {
         throw new IllegalStateException("Unexpected call to " + getClass().getSimpleName() + "'s setUp() method. Only the execute() method should be called.");
@@ -23,28 +21,23 @@ public class SpecificationCommand extends AbstractCommand {
     
     @Override
     public void execute(CommandCall commandCall, Evaluator evaluator, ResultRecorder resultRecorder) {
-
-        specificationExecuted = true;
-
         if (specificationDescriber != null) {
             resultRecorder.setSpecificationDescription(specificationDescriber.getDescription(commandCall.getResource()));
         }
 
-        announceBeforeProcessingEvent(commandCall.getResource(), commandCall.getElement());
         try {
             commandCall.getChildren().processSequentially(evaluator, resultRecorder);
         } catch (FailFastException e) {
             // Ignore - it'll be re-thrown later if necessary.
         }
-        announceAfterProcessingEvent(commandCall.getResource(), commandCall.getElement());
+    }
+
+    public void start(CommandCall commandCall) {
+        announceBeforeProcessingEvent(commandCall.getResource(), commandCall.getElement());
     }
 
     public void finish(CommandCall commandCall) {
-
-        if (!specificationExecuted) {
-            announceBeforeProcessingEvent(commandCall.getResource(), commandCall.getElement());
-            announceAfterProcessingEvent(commandCall.getResource(), commandCall.getElement());
-        }
+        announceAfterProcessingEvent(commandCall.getResource(), commandCall.getElement());
     }
 
     @Override

--- a/src/test/java/spec/concordion/extension/AbstractExtensionTestCase.java
+++ b/src/test/java/spec/concordion/extension/AbstractExtensionTestCase.java
@@ -50,6 +50,7 @@ public abstract class AbstractExtensionTestCase {
         String[] events = baos.toString().split("\\r?\\n");
         eventList = new ArrayList<String>(Arrays.asList(events));
         eventList.remove("");
+        baos.reset();
         return eventList;
     }
 

--- a/src/test/java/spec/concordion/extension/listener/ListenerTest.java
+++ b/src/test/java/spec/concordion/extension/listener/ListenerTest.java
@@ -4,13 +4,23 @@ import org.concordion.integration.junit4.ConcordionRunner;
 import org.junit.runner.RunWith;
 
 import spec.concordion.extension.AbstractExtensionTestCase;
+import test.concordion.extension.ExampleProcessingExtension;
 import test.concordion.extension.LoggingExtension;
+import test.concordion.extension.ProcessingExtension;
 
 @RunWith(ConcordionRunner.class)
 public class ListenerTest extends AbstractExtensionTestCase {
 
     public void addLoggingExtension() {
         setExtension(new LoggingExtension().withStream(getLogStream()));
+    }
+    
+    public void addProcessingExtension() {
+        setExtension(new ProcessingExtension().withStream(getLogStream()));
+    }
+    
+    public void addExampleProcessingExtension() {
+        setExtension(new ExampleProcessingExtension().withStream(getLogStream()));
     }
     
     public double sqrt(double num) {

--- a/src/test/java/test/concordion/TestRig.java
+++ b/src/test/java/test/concordion/TestRig.java
@@ -75,6 +75,7 @@ public class TestRig {
                     resultSummary = concordion.processExample(example);
                 }
             }
+            concordion.finish();
 
             String xml = stubTarget.getWrittenString(resource);
             

--- a/src/test/java/test/concordion/TestRig.java
+++ b/src/test/java/test/concordion/TestRig.java
@@ -1,6 +1,7 @@
 package test.concordion;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.concordion.Concordion;
 import org.concordion.api.EvaluatorFactory;
@@ -64,8 +65,19 @@ public class TestRig {
         }
 
         try {
-            ResultSummary resultSummary = concordion.process(resource, fixture);
+
+//            ResultSummary resultSummary = concordion.process(resource, fixture);
+            ResultSummary resultSummary = null;
+            concordion.override(resource, fixture);
+            List<String> examples = concordion.getExampleNames();
+            if (!examples.isEmpty()) {
+                for (String example : examples) {
+                    resultSummary = concordion.processExample(example);
+                }
+            }
+
             String xml = stubTarget.getWrittenString(resource);
+            
             return new ProcessingResult(resultSummary, eventRecorder, xml);
         } catch (IOException e) {
             throw new RuntimeException("Test rig failed to process specification", e);

--- a/src/test/java/test/concordion/extension/ConcordionBuildLogger.java
+++ b/src/test/java/test/concordion/extension/ConcordionBuildLogger.java
@@ -1,0 +1,19 @@
+package test.concordion.extension;
+
+import java.io.PrintStream;
+
+import org.concordion.api.listener.*;
+
+public class ConcordionBuildLogger implements ConcordionBuildListener {
+    
+    private PrintStream stream;
+
+    public void setStream(PrintStream stream) {
+        this.stream = stream;
+    }
+
+    @Override
+    public void concordionBuilt(ConcordionBuildEvent event) {
+        stream.println("Concordion Built");
+    }
+}

--- a/src/test/java/test/concordion/extension/DocumentParsingLogger.java
+++ b/src/test/java/test/concordion/extension/DocumentParsingLogger.java
@@ -1,0 +1,21 @@
+package test.concordion.extension;
+
+import java.io.PrintStream;
+
+import nu.xom.Document;
+
+import org.concordion.api.listener.*;
+
+public class DocumentParsingLogger implements DocumentParsingListener {
+    
+    private PrintStream stream;
+
+    public void setStream(PrintStream stream) {
+        this.stream = stream;
+    }
+
+    @Override
+    public void beforeParsing(Document document) {
+        stream.println("Before Parsing Document");
+    }
+}

--- a/src/test/java/test/concordion/extension/ExampleLogger.java
+++ b/src/test/java/test/concordion/extension/ExampleLogger.java
@@ -1,0 +1,24 @@
+package test.concordion.extension;
+
+import java.io.PrintStream;
+
+import org.concordion.api.listener.*;
+
+public class ExampleLogger implements ExampleListener {
+    
+    private PrintStream stream;
+
+    public void setStream(PrintStream stream) {
+        this.stream = stream;
+    }
+
+    @Override
+    public void beforeExample(ExampleEvent event) {
+        stream.println(String.format("Before example '%s'", event.getExampleName()));
+    }
+
+    @Override
+    public void afterExample(ExampleEvent event) {
+        stream.println(String.format("After example '%s'", event.getExampleName()));
+    }
+}

--- a/src/test/java/test/concordion/extension/ExampleProcessingExtension.java
+++ b/src/test/java/test/concordion/extension/ExampleProcessingExtension.java
@@ -1,0 +1,32 @@
+package test.concordion.extension;
+
+import java.io.PrintStream;
+
+import org.concordion.api.extension.ConcordionExtender;
+import org.concordion.api.extension.ConcordionExtension;
+
+public class ExampleProcessingExtension implements ConcordionExtension {
+
+    private AssertLogger assertLogger = new AssertLogger();
+    private ConcordionBuildLogger concordionBuildLogger = new ConcordionBuildLogger();
+    private SpecificationProcessingLogger specificationProcessingLogger = new SpecificationProcessingLogger();
+    private DocumentParsingLogger documentParsingLogger = new DocumentParsingLogger();
+    private ExampleLogger exampleLogger = new ExampleLogger();
+
+    public void addTo(ConcordionExtender concordionExtender) {
+        concordionExtender.withAssertEqualsListener(assertLogger);
+        concordionExtender.withBuildListener(concordionBuildLogger);
+        concordionExtender.withSpecificationProcessingListener(specificationProcessingLogger);
+        concordionExtender.withDocumentParsingListener(documentParsingLogger);
+        concordionExtender.withExampleListener(exampleLogger);
+    }
+    
+    public ExampleProcessingExtension withStream(PrintStream stream) {
+        assertLogger.setStream(stream);
+        concordionBuildLogger.setStream(stream);
+        specificationProcessingLogger.setStream(stream);
+        documentParsingLogger.setStream(stream);
+        exampleLogger.setStream(stream);
+        return this;
+    }
+}

--- a/src/test/java/test/concordion/extension/ProcessingExtension.java
+++ b/src/test/java/test/concordion/extension/ProcessingExtension.java
@@ -1,0 +1,29 @@
+package test.concordion.extension;
+
+import java.io.PrintStream;
+
+import org.concordion.api.extension.ConcordionExtender;
+import org.concordion.api.extension.ConcordionExtension;
+
+public class ProcessingExtension implements ConcordionExtension {
+
+    private AssertLogger assertLogger = new AssertLogger();
+    private ConcordionBuildLogger concordionBuildLogger = new ConcordionBuildLogger();
+    private SpecificationProcessingLogger specificationProcessingLogger = new SpecificationProcessingLogger();
+    private DocumentParsingLogger documentParsingLogger = new DocumentParsingLogger();
+
+    public void addTo(ConcordionExtender concordionExtender) {
+        concordionExtender.withAssertEqualsListener(assertLogger);
+        concordionExtender.withBuildListener(concordionBuildLogger);
+        concordionExtender.withSpecificationProcessingListener(specificationProcessingLogger);
+        concordionExtender.withDocumentParsingListener(documentParsingLogger);
+    }
+    
+    public ProcessingExtension withStream(PrintStream stream) {
+        assertLogger.setStream(stream);
+        concordionBuildLogger.setStream(stream);
+        specificationProcessingLogger.setStream(stream);
+        documentParsingLogger.setStream(stream);
+        return this;
+    }
+}

--- a/src/test/java/test/concordion/extension/SpecificationProcessingLogger.java
+++ b/src/test/java/test/concordion/extension/SpecificationProcessingLogger.java
@@ -1,0 +1,24 @@
+package test.concordion.extension;
+
+import java.io.PrintStream;
+
+import org.concordion.api.listener.*;
+
+public class SpecificationProcessingLogger implements SpecificationProcessingListener {
+    
+    private PrintStream stream;
+
+    public void setStream(PrintStream stream) {
+        this.stream = stream;
+    }
+
+    @Override
+    public void beforeProcessingSpecification(SpecificationProcessingEvent event) {
+        stream.println("Before Processing " + event.getResource());
+    }
+
+    @Override
+    public void afterProcessingSpecification(SpecificationProcessingEvent event) {
+        stream.println("After Processing " + event.getResource());
+    }
+}

--- a/src/test/resources/spec/concordion/extension/listener/Listener.html
+++ b/src/test/resources/spec/concordion/extension/listener/Listener.html
@@ -77,6 +77,70 @@ is &lt;span concordion:assertFalse="isPositive(#num)"&gt;is not positive&lt;/spa
         <li><code>Specification processing listeners</code> provide access to the <code>specification</code> before and after processing</li>
     </ul>
 
+    <div class="example">
+
+        <h3>Example</h3>
+        
+        <p>An <span concordion:execute="addProcessingExtension()">extension is installed</span> with a ConcordionBuildListener, DocumentParsingListener, SpecificationProcesssingListener and AssertEqualsListener. When the following instrumentation:</p> 
+<pre concordion:set="#result = process(#TEXT)">
+&lt;p&gt;The square root of &lt;span concordion:set="#num"&gt;16.0&lt;/span&gt; is &lt;span concordion:assertEquals="sqrt(#num)"&gt;4.0&lt;/span&gt;&lt;/p&gt;
+</pre>
+
+        <p>is run with a fixture that performs the arithmetical operations, the logged events are:
+        </p>
+        <table concordion:verifyRows="#event : getEventLog()">
+        <tr><th concordion:assertEquals="#event">Event</th></tr>
+        <tr><td>Concordion Built</td></tr>
+        <tr><td>Before Parsing Document</td></tr>
+        <tr><td>Before Processing [Resource: /testrig]</td></tr>
+        <tr><td>Success '4.0'</td></tr>
+        <tr><td>After Processing [Resource: /testrig]</td></tr>
+        </table>
+
+    </div>
+
+    <div class="example" concordion:example="Example with examples" concordion:status="ExpectedToFail">
+
+        <h3>Example with concordion:example</h3>
+        
+        <p>An <span concordion:execute="addExampleProcessingExtension()">extension is installed</span> with a ConcordionBuildListener, DocumentParsingListener, SpecificationProcesssingListener, ExampleListener and AssertEqualsListener. When the following instrumentation:</p> 
+<pre concordion:set="#result = process(#TEXT)">
+&lt;div concordion:example="before"&gt;
+&lt;/div&gt;
+
+&lt;div concordion:example="example1"&gt;
+&lt;p&gt;The square root of &lt;span concordion:set="#num"&gt;16.0&lt;/span&gt; is &lt;span concordion:assertEquals="sqrt(#num)"&gt;4.0&lt;/span&gt;&lt;/p&gt;
+&lt;/div&gt;
+
+&lt;div concordion:example="example2"&gt;
+&lt;p&gt;The square root of &lt;span concordion:set="#num"&gt;9.0&lt;/span&gt; is &lt;span concordion:assertEquals="sqrt(#num)"&gt;3.0&lt;/span&gt;&lt;/p&gt;
+&lt;/div&gt;
+</pre>
+
+        <p>is run with a fixture that performs the arithmetical operations, the logged events are:
+        </p>
+        <table concordion:verifyRows="#event : getEventLog()">
+        <tr><th concordion:assertEquals="#event">Event</th></tr>
+        <tr><td>Concordion Built</td></tr>
+        <tr><td>Before Parsing Document</td></tr>
+        <tr><td>Before Processing [Resource: /testrig]</td></tr>
+        <tr><td>Before example 'before'</td></tr>
+        <tr><td>After example 'before'</td></tr>
+        <tr><td>Before example 'example1'</td></tr>
+        <tr><td>Success '4.0'</td></tr>
+        <tr><td>After example 'example1'</td></tr>
+        <tr><td>Before example 'before'</td></tr>
+        <tr><td>After example 'before'</td></tr>
+        <tr><td>Before example 'example2'</td></tr>
+        <tr><td>Success '3.0'</td></tr>
+        <tr><td>After example 'example2'</td></tr>
+        <tr><td>Before example 'before'</td></tr>
+        <tr><td>After example 'before'</td></tr>
+        <tr><td>After Processing [Resource: /testrig]</td></tr>
+        </table>
+
+    </div>
+
     <h2>Further Details</h2>
 
     <ul>

--- a/src/test/resources/spec/concordion/extension/listener/Listener.html
+++ b/src/test/resources/spec/concordion/extension/listener/Listener.html
@@ -99,7 +99,7 @@ is &lt;span concordion:assertFalse="isPositive(#num)"&gt;is not positive&lt;/spa
 
     </div>
 
-    <div class="example" concordion:example="Example with examples" concordion:status="ExpectedToFail">
+    <div class="example" concordion:example="Example with examples">
 
         <h3>Example with concordion:example</h3>
         

--- a/src/test/resources/spec/concordion/extension/listener/Listener.html
+++ b/src/test/resources/spec/concordion/extension/listener/Listener.html
@@ -134,8 +134,42 @@ is &lt;span concordion:assertFalse="isPositive(#num)"&gt;is not positive&lt;/spa
         <tr><td>Before example 'example2'</td></tr>
         <tr><td>Success '3.0'</td></tr>
         <tr><td>After example 'example2'</td></tr>
+        <tr><td>After Processing [Resource: /testrig]</td></tr>
+        </table>
+
+    </div>
+
+    <div class="example" concordion:example="Example with mixed examples">
+
+        <h3>Example with mixture of concordion:example and anonymous example</h3>
+        
+        <p>An <span concordion:execute="addExampleProcessingExtension()">extension is installed</span> with a ConcordionBuildListener, DocumentParsingListener, SpecificationProcesssingListener, ExampleListener and AssertEqualsListener. When the following instrumentation:</p> 
+<pre concordion:set="#result = process(#TEXT)">
+&lt;div concordion:example="before"&gt;
+&lt;/div&gt;
+
+&lt;div concordion:example="example1"&gt;
+&lt;p&gt;The square root of &lt;span concordion:set="#num"&gt;16.0&lt;/span&gt; is &lt;span concordion:assertEquals="sqrt(#num)"&gt;4.0&lt;/span&gt;&lt;/p&gt;
+&lt;/div&gt;
+
+&lt;p&gt;The square root of &lt;span concordion:set="#num"&gt;9.0&lt;/span&gt; is &lt;span concordion:assertEquals="sqrt(#num)"&gt;3.0&lt;/span&gt;&lt;/p&gt;
+</pre>
+
+        <p>is run with a fixture that performs the arithmetical operations, the logged events are:
+        </p>
+        <table concordion:verifyRows="#event : getEventLog()">
+        <tr><th concordion:assertEquals="#event">Event</th></tr>
+        <tr><td>Concordion Built</td></tr>
+        <tr><td>Before Parsing Document</td></tr>
+        <tr><td>Before Processing [Resource: /testrig]</td></tr>
         <tr><td>Before example 'before'</td></tr>
         <tr><td>After example 'before'</td></tr>
+        <tr><td>Before example 'example1'</td></tr>
+        <tr><td>Success '4.0'</td></tr>
+        <tr><td>After example 'example1'</td></tr>
+        <tr><td>Before example 'before'</td></tr>
+        <tr><td>After example 'before'</td></tr>
+        <tr><td>Success '3.0'</td></tr>
         <tr><td>After Processing [Resource: /testrig]</td></tr>
         </table>
 


### PR DESCRIPTION
@drtimwright would you review please?

Two things to look at in particular:

1. In XMLSpecification.java, the typecasting of the root command to `SpecificationCommand` so that we can remove `finish()` method from `Command` interface (and add a `start()` method to `SpecificationCommand` without bloating `Command` interface further).
2. In the Listener.html spec, that the `before` example is run 3 times; before each of the 2 examples and then after them. I assume the last one is for any commands outside of the examples. Do you think we should special case this and only run the `before` example if the main spec has other commands?

cheers

/cc @andrew-sumner 