### PR TITLE
Workaround for buffer overflow issue with OpenJDK 6 compile on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+# workaround for buffer overflow issue, ref https://github.com/travis-ci/travis-ci/issues/5227
+before_install:
+  - cat /etc/hosts # optionally check the content *before*
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - cat /etc/hosts # optionally check the content *after*
+
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/5227 for further details.