### PR TITLE
Added specification name to SpecificaionConverter.

### DIFF
--- a/src/main/java/org/concordion/api/SpecificationConverter.java
+++ b/src/main/java/org/concordion/api/SpecificationConverter.java
@@ -11,10 +11,11 @@ import java.io.InputStream;
 public interface SpecificationConverter {
 
     /**
-     * Convert the resource's input stream to an HTML input stream.
-     * @param inputStream the input stream containing the content of the resource
-     * @return converted resource's content
+     * Convert the specification's input stream to an HTML input stream.
+     * @param inputStream the input stream containing the content of the specification
+     * @param specificationName the filename of the specification (without the path)
+     * @return converted specification content
      * @throws IOException on i/o error
      */
-    InputStream convert(InputStream inputStream) throws IOException;
+    InputStream convert(InputStream inputStream, String specificationName) throws IOException;
 }

--- a/src/main/java/org/concordion/internal/XMLSpecificationReader.java
+++ b/src/main/java/org/concordion/internal/XMLSpecificationReader.java
@@ -59,7 +59,7 @@ public class XMLSpecificationReader implements SpecificationReader {
     private InputStream asHtmlStream(Resource resource) throws IOException {
         InputStream inputStream = source.createInputStream(resource);
         if (specificationConverter != null) {
-            inputStream = specificationConverter.convert(inputStream);
+            inputStream = specificationConverter.convert(inputStream, resource.getName());
         }
         if (copySourceHtmlTarget != null) {
             inputStream = copySourceHtml(resource, inputStream);

--- a/src/main/java/org/concordion/internal/listener/BreadcrumbRenderer.java
+++ b/src/main/java/org/concordion/internal/listener/BreadcrumbRenderer.java
@@ -109,7 +109,7 @@ public class BreadcrumbRenderer implements SpecificationProcessingListener {
         if (breadcrumbWording == null) {
             InputStream inputStream = source.createInputStream(indexPageResource);
             if (specificationConverter != null) {
-                inputStream = specificationConverter.convert(inputStream);
+                inputStream = specificationConverter.convert(inputStream, indexPageResource.getName());
             }
             Document document = xmlParser.parse(inputStream, String.format("[%s: %s]", source, indexPageResource.getPath()));
 

--- a/src/main/java/org/concordion/internal/parser/markdown/MarkdownConverter.java
+++ b/src/main/java/org/concordion/internal/parser/markdown/MarkdownConverter.java
@@ -14,7 +14,7 @@ public class MarkdownConverter implements SpecificationConverter {
     private int pegdownExtensions;
 
     @Override
-    public InputStream convert(InputStream inputStream) throws IOException {
+    public InputStream convert(InputStream inputStream, String specificationName) throws IOException {
         String markdown = asString(inputStream);
         MarkdownParser markdownParser = new MarkdownParser(pegdownExtensions);
         String html = markdownParser.markdownToHtml(markdown, CONCORDION_NAMESPACE_PREFIX);


### PR DESCRIPTION
The ExcelExtension uses the specification name for an HTML header.
See concordion/concordion-excel-extension#5