### PR TITLE
performance: replace String.format with SimpleFormatter & toUpperCase on Character

### DIFF
--- a/src/main/java/org/concordion/internal/FixtureInstance.java
+++ b/src/main/java/org/concordion/internal/FixtureInstance.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import org.concordion.api.*;
 import org.concordion.internal.scopedObjects.ScopedFieldStore;
+import org.concordion.internal.util.SimpleFormatter;
 
 public class FixtureInstance extends FixtureType implements Fixture, FixtureDeclarations {
     private final Object fixtureObject;
@@ -43,7 +44,7 @@ public class FixtureInstance extends FixtureType implements Fixture, FixtureDecl
     @Override
     public String getSpecificationDescription() {
         String name = removeSuffix(fixtureClass.getSimpleName());
-        return String.format("[Concordion Specification for '%s']", name); // Based on suggestion by Danny Guerrier
+        return SimpleFormatter.format("[Concordion Specification for '%s']", name); // Based on suggestion by Danny Guerrier
     }
 
     @Override

--- a/src/main/java/org/concordion/internal/XMLSpecificationReader.java
+++ b/src/main/java/org/concordion/internal/XMLSpecificationReader.java
@@ -9,6 +9,7 @@ import nu.xom.Document;
 
 import org.concordion.api.*;
 import org.concordion.internal.util.IOUtil;
+import org.concordion.internal.util.SimpleFormatter;
 
 public class XMLSpecificationReader implements SpecificationReader {
 
@@ -28,7 +29,7 @@ public class XMLSpecificationReader implements SpecificationReader {
         InputStream inputStream = asHtmlStream(resource);
         Document document;
         try {
-            document = xmlParser.parse(inputStream, String.format("[%s: %s]", source, resource.getPath()));
+            document = xmlParser.parse(inputStream, SimpleFormatter.format("[%s: %s]", source, resource.getPath()));
         } catch (ParsingException e) {
             if (specificationConverter != null) {
                 System.err.println("Error parsing generated HTML:\n" + IOUtil.readAsString(asHtmlStream(resource)));
@@ -82,7 +83,7 @@ public class XMLSpecificationReader implements SpecificationReader {
     
     private InputStream copySourceHtml(Resource resource, InputStream inputStream) throws IOException {
         Resource sourceHtmlResource = new Resource(resource.getPath() + ".html");
-        System.out.println(String.format("[Source: %s]", copySourceHtmlTarget.resolvedPathFor(sourceHtmlResource)));
+        System.out.println(SimpleFormatter.format("[Source: %s]", copySourceHtmlTarget.resolvedPathFor(sourceHtmlResource)));
         String html = asString(inputStream);
         copySourceHtmlTarget.write(sourceHtmlResource, html);
         inputStream = new ByteArrayInputStream(html.getBytes());

--- a/src/main/java/org/concordion/internal/listener/BreadcrumbRenderer.java
+++ b/src/main/java/org/concordion/internal/listener/BreadcrumbRenderer.java
@@ -147,7 +147,7 @@ public class BreadcrumbRenderer implements SpecificationProcessingListener {
         if (s.equals("")) {
             return "";
         }
-        return s.substring(0, 1).toUpperCase() + s.substring(1);
+        return Character.toUpperCase(s.charAt(0)) + s.substring(1);
     }
 
     private String stripExtension(String s) {

--- a/src/main/java/org/concordion/internal/listener/BreadcrumbRenderer.java
+++ b/src/main/java/org/concordion/internal/listener/BreadcrumbRenderer.java
@@ -18,6 +18,7 @@ import org.concordion.api.listener.SpecificationProcessingEvent;
 import org.concordion.api.listener.SpecificationProcessingListener;
 import org.concordion.internal.SpecificationType;
 import org.concordion.internal.XMLParser;
+import org.concordion.internal.util.SimpleFormatter;
 
 public class BreadcrumbRenderer implements SpecificationProcessingListener {
 
@@ -111,7 +112,7 @@ public class BreadcrumbRenderer implements SpecificationProcessingListener {
             if (specificationConverter != null) {
                 inputStream = specificationConverter.convert(inputStream);
             }
-            Document document = xmlParser.parse(inputStream, String.format("[%s: %s]", source, indexPageResource.getPath()));
+            Document document = xmlParser.parse(inputStream, SimpleFormatter.format("[%s: %s]", source, indexPageResource.getPath()));
 
             breadcrumbWording = getBreadcrumbWording(new Element(document.getRootElement()), indexPageResource);
             breadcrumbWordingCache.put(indexPageResource, breadcrumbWording);

--- a/src/main/java/org/concordion/internal/listener/SpecificationExporter.java
+++ b/src/main/java/org/concordion/internal/listener/SpecificationExporter.java
@@ -7,6 +7,7 @@ import org.concordion.api.Target;
 import org.concordion.api.listener.SpecificationProcessingEvent;
 import org.concordion.api.listener.SpecificationProcessingListener;
 import org.concordion.internal.SpecificationDescriber;
+import org.concordion.internal.util.SimpleFormatter;
 
 public class SpecificationExporter implements SpecificationProcessingListener, SpecificationDescriber {
 
@@ -34,7 +35,7 @@ public class SpecificationExporter implements SpecificationProcessingListener, S
     }
 
     public String getDescription(Resource resource, String exampleName) {
-        return String.format("%s#%s", getDescription(resource), exampleName);
+        return SimpleFormatter.format("%s#%s", getDescription(resource), exampleName);
     }
 
 }

--- a/src/main/java/org/concordion/internal/util/SimpleFormatter.java
+++ b/src/main/java/org/concordion/internal/util/SimpleFormatter.java
@@ -1,0 +1,26 @@
+package org.concordion.internal.util;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SimpleFormatter {
+	
+	public static String format(String format, Object... args) {
+		StringBuilder result = new StringBuilder();
+		String[] stringElements = format.split("%s");
+		if (format.endsWith("%s")) {
+			List<String> stringElementsList = Arrays.asList(stringElements);
+			stringElements = stringElementsList.toArray(new String[stringElements.length + 1]);
+			stringElements[stringElements.length - 1] = "";
+		}
+		result.append(stringElements[0]);
+		for (int i = 1; i < stringElements.length; i++) {
+			if (args != null && args.length >= i && args[i-1] != null) {
+				result.append(args[i-1].toString());
+			}
+			result.append(stringElements[i]);
+		}
+		return result.toString();
+	}
+
+}

--- a/src/test/java/test/org/concordion/internal/util/SimpleFormatterTest.java
+++ b/src/test/java/test/org/concordion/internal/util/SimpleFormatterTest.java
@@ -1,0 +1,59 @@
+package test.org.concordion.internal.util;
+
+import static org.junit.Assert.*;
+
+import org.concordion.internal.util.SimpleFormatter;
+import org.junit.Test;
+
+public class SimpleFormatterTest {
+
+	@Test
+	public void testFormatWithoutSpecifiers() {
+		String format = "some text";
+		String formattedString = SimpleFormatter.format(format);
+		assertEquals(format, formattedString);
+	}
+	
+	@Test
+	public void testFormatWithStartingConversion() {
+		String format = "%s specifier";
+		String formattedString = SimpleFormatter.format(format, "text with");
+		assertEquals("text with specifier", formattedString);
+	}
+	
+	@Test
+	public void testFormatWithConversion() {
+		String format = "text %s specifier";
+		String formattedString = SimpleFormatter.format(format, "with");
+		assertEquals("text with specifier", formattedString);
+	}
+	
+	@Test
+	public void testFormatWithEndingConversion() {
+		String format = "text %s";
+		String formattedString = SimpleFormatter.format(format, "formatted");
+		assertEquals("text formatted", formattedString);
+	}
+	
+	@Test
+	public void testFormatWithConversionAtStartAndEnd() {
+		String format = "%s text %s the %s";
+		String formattedString = SimpleFormatter.format(format, "some", "in", "middle");
+		assertEquals("some text in the middle", formattedString);
+	}
+	
+	@Test
+	public void testFormatWithMissingArgs() {
+		String format = "%s specifier";
+		String formattedString = SimpleFormatter.format(format);
+		assertEquals(" specifier", formattedString);
+	}
+	
+	@Test
+	public void testFormatWithNullArgs() {
+		String format = "%s specifier";
+		String formattedString = SimpleFormatter.format(format, null);
+		assertEquals(" specifier", formattedString);
+	}
+
+}


### PR DESCRIPTION
String.format() and String.toUpperCase() load the entire internationalization engine. Therefore, they consume much time on the .NET platform.
SimpleFormatter just uses string concatenation.
As only the first letter needs to be converted to upper case, this can be done with Character.toUpperCase(), which does not depend on internationalization.