### PR TITLE
Tidy up SpecificationLocator

### DIFF
--- a/src/main/java/org/concordion/Concordion.java
+++ b/src/main/java/org/concordion/Concordion.java
@@ -16,6 +16,15 @@ public class Concordion {
     private Resource resource;
     private SpecificationByExample specification;
 
+    /**
+     * @deprecated use {@link #Concordion(List, SpecificationLocator, SpecificationReader, EvaluatorFactory, Fixture)} instead
+     * @param specificationLocator locates the specification based on the specification type
+     * @param specificationReader specification reader
+     * @param evaluatorFactory evaluator factory
+     * @param fixture fixture instance 
+     * @throws IOException on i/o error
+     */
+    @Deprecated
     public Concordion(SpecificationLocator specificationLocator, SpecificationReader specificationReader, EvaluatorFactory evaluatorFactory, Fixture fixture) throws IOException {
         this.specificationReader = specificationReader;
         this.evaluatorFactory = evaluatorFactory;
@@ -34,15 +43,14 @@ public class Concordion {
      * @param fixture fixture instance 
      * @throws IOException on i/o error
      */
-    public Concordion(List<SpecificationType> specificationTypes, SpecificationLocatorWithType specificationLocator, SpecificationReader specificationReader, EvaluatorFactory evaluatorFactory, Fixture fixture) throws IOException {
+    public Concordion(List<SpecificationType> specificationTypes, SpecificationLocator specificationLocator, SpecificationReader specificationReader, EvaluatorFactory evaluatorFactory, Fixture fixture) throws IOException {
         this.specificationReader = specificationReader;
         this.evaluatorFactory = evaluatorFactory;
 
         SpecificationType specificationType = null;
 
-        SpecificationLocatorWithType specificationTypeLocator = (SpecificationLocatorWithType)specificationLocator;
         for (SpecificationType currentType : specificationTypes) {
-            Resource currentResource = specificationTypeLocator.locateSpecification(fixture.getFixtureObject(), currentType.getTypeSuffix());
+            Resource currentResource = specificationLocator.locateSpecification(fixture.getFixtureObject(), currentType.getTypeSuffix());
             if (specificationReader.canFindSpecification(currentResource)) {
                 if (specificationType != null) {
                     throw new RuntimeException(createMultipleSpecsMessage(fixture, specificationType, currentType));

--- a/src/main/java/org/concordion/api/SpecificationLocator.java
+++ b/src/main/java/org/concordion/api/SpecificationLocator.java
@@ -1,5 +1,22 @@
 package org.concordion.api;
 
 public interface SpecificationLocator {
+    /**
+     * @deprecated - use {@link #locateSpecification(Object, String)} instead  
+     * Locates the specification for the named fixture, assuming a fixed type suffix (eg. HTML).
+     * @param fixture the fixture to find the specification for
+     * @return the resource for the specification, which may or may not actually exist
+     */
+    @Deprecated
     Resource locateSpecification(Object fixture);
+    
+    /**
+     * Locates a specification, allowing the type suffix of the specification to be specified.
+     * @param fixtureObject the fixture to find the specification for
+     * @param typeSuffix the suffix of the specification
+     * @return the resource for the specification, which may or may not actually exist
+     *
+     * @since 2.0.0
+     */
+    Resource locateSpecification(Object fixtureObject, String typeSuffix);
 }

--- a/src/main/java/org/concordion/internal/ClassNameAndTypeBasedSpecificationLocator.java
+++ b/src/main/java/org/concordion/internal/ClassNameAndTypeBasedSpecificationLocator.java
@@ -1,14 +1,6 @@
 package org.concordion.internal;
 
-import org.concordion.api.Resource;
 import org.concordion.api.SpecificationLocatorWithType;
-import org.concordion.internal.util.Check;
 
 public class ClassNameAndTypeBasedSpecificationLocator extends ClassNameBasedSpecificationLocator implements SpecificationLocatorWithType {
-
-    @Override
-    public Resource locateSpecification(Object fixture, String typeSuffix) {
-        Check.notNull(fixture, "Fixture is null");
-        return FixtureSpecificationMapper.toSpecificationResource(fixture, typeSuffix);
-    }
 }

--- a/src/main/java/org/concordion/internal/ClassNameBasedSpecificationLocator.java
+++ b/src/main/java/org/concordion/internal/ClassNameBasedSpecificationLocator.java
@@ -21,4 +21,10 @@ public class ClassNameBasedSpecificationLocator implements SpecificationLocator 
         Check.notNull(fixture, "Fixture is null");
         return FixtureSpecificationMapper.toSpecificationResource(fixture, specificationSuffix);
     }
+
+    @Override
+    public Resource locateSpecification(Object fixture, String typeSuffix) {
+        Check.notNull(fixture, "Fixture is null");
+        return FixtureSpecificationMapper.toSpecificationResource(fixture, typeSuffix);
+    }
 }

--- a/src/main/java/org/concordion/internal/ConcordionBuilder.java
+++ b/src/main/java/org/concordion/internal/ConcordionBuilder.java
@@ -288,11 +288,7 @@ public class ConcordionBuilder implements ConcordionExtender {
         announceBuildCompleted();
 
         try {
-            if (specificationLocator instanceof SpecificationLocatorWithType) {
-                return new Concordion(specificationTypes, (SpecificationLocatorWithType)specificationLocator, specificationReader, evaluatorFactory, fixture);
-            } else {
-                return new Concordion(specificationLocator, specificationReader, evaluatorFactory, fixture);
-            }
+            return new Concordion(specificationTypes, specificationLocator, specificationReader, evaluatorFactory, fixture);
         } catch (IOException e) {
             throw new UnableToBuildConcordionException(e);
         }

--- a/src/main/java/org/concordion/internal/DocumentParser.java
+++ b/src/main/java/org/concordion/internal/DocumentParser.java
@@ -1,23 +1,17 @@
 package org.concordion.internal;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import nu.xom.Attribute;
 import nu.xom.Document;
 import nu.xom.Elements;
 
-import org.concordion.api.Command;
-import org.concordion.api.CommandCall;
-import org.concordion.api.CommandFactory;
-import org.concordion.api.Element;
-import org.concordion.api.Resource;
-import org.concordion.api.Specification;
+import org.concordion.api.*;
 import org.concordion.api.listener.DocumentParsingListener;
 import org.concordion.internal.util.Check;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class DocumentParser {
 

--- a/src/main/java/org/concordion/internal/command/AssertEqualsCommand.java
+++ b/src/main/java/org/concordion/internal/command/AssertEqualsCommand.java
@@ -1,16 +1,10 @@
 package org.concordion.internal.command;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import org.concordion.api.AbstractCommand;
-import org.concordion.api.CommandCall;
-import org.concordion.api.Element;
-import org.concordion.api.Evaluator;
-import org.concordion.api.Result;
-import org.concordion.api.ResultRecorder;
+import org.concordion.api.*;
 import org.concordion.api.listener.AssertEqualsListener;
 import org.concordion.api.listener.AssertFailureEvent;
 import org.concordion.api.listener.AssertSuccessEvent;

--- a/src/main/java/org/concordion/internal/command/BooleanCommand.java
+++ b/src/main/java/org/concordion/internal/command/BooleanCommand.java
@@ -1,15 +1,9 @@
 package org.concordion.internal.command;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-import org.concordion.api.AbstractCommand;
-import org.concordion.api.CommandCall;
-import org.concordion.api.CommandCallList;
-import org.concordion.api.Element;
-import org.concordion.api.Evaluator;
-import org.concordion.api.ResultRecorder;
+import org.concordion.api.*;
 import org.concordion.api.listener.AssertFailureEvent;
 import org.concordion.api.listener.AssertListener;
 import org.concordion.api.listener.AssertSuccessEvent;

--- a/src/main/java/org/concordion/internal/command/ExampleCommand.java
+++ b/src/main/java/org/concordion/internal/command/ExampleCommand.java
@@ -2,7 +2,6 @@ package org.concordion.internal.command;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.concordion.api.*;

--- a/src/main/java/org/concordion/internal/command/ExecuteCommand.java
+++ b/src/main/java/org/concordion/internal/command/ExecuteCommand.java
@@ -1,7 +1,6 @@
 package org.concordion.internal.command;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.concordion.api.*;

--- a/src/main/java/org/concordion/internal/command/RunCommand.java
+++ b/src/main/java/org/concordion/internal/command/RunCommand.java
@@ -2,15 +2,10 @@ package org.concordion.internal.command;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.concordion.api.*;
-import org.concordion.api.listener.RunFailureEvent;
-import org.concordion.api.listener.RunIgnoreEvent;
-import org.concordion.api.listener.RunListener;
-import org.concordion.api.listener.RunSuccessEvent;
-import org.concordion.api.listener.ThrowableCaughtEvent;
+import org.concordion.api.listener.*;
 import org.concordion.internal.ConcordionAssertionError;
 import org.concordion.internal.FailFastException;
 import org.concordion.internal.runner.DefaultConcordionRunner;

--- a/src/main/java/org/concordion/internal/command/SetCommand.java
+++ b/src/main/java/org/concordion/internal/command/SetCommand.java
@@ -1,14 +1,9 @@
 package org.concordion.internal.command;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-import org.concordion.api.AbstractCommand;
-import org.concordion.api.CommandCall;
-import org.concordion.api.Element;
-import org.concordion.api.Evaluator;
-import org.concordion.api.ResultRecorder;
+import org.concordion.api.*;
 import org.concordion.api.listener.SetEvent;
 import org.concordion.api.listener.SetListener;
 import org.concordion.internal.util.Check;

--- a/src/main/java/org/concordion/internal/command/SpecificationCommand.java
+++ b/src/main/java/org/concordion/internal/command/SpecificationCommand.java
@@ -1,7 +1,6 @@
 package org.concordion.internal.command;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.concordion.api.*;

--- a/src/main/java/org/concordion/internal/command/ThrowableCatchingDecorator.java
+++ b/src/main/java/org/concordion/internal/command/ThrowableCatchingDecorator.java
@@ -1,7 +1,6 @@
 package org.concordion.internal.command;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.concordion.api.*;

--- a/src/main/java/org/concordion/internal/command/ThrowableCaughtPublisher.java
+++ b/src/main/java/org/concordion/internal/command/ThrowableCaughtPublisher.java
@@ -1,7 +1,6 @@
 package org.concordion.internal.command;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.concordion.api.listener.ThrowableCaughtEvent;

--- a/src/main/java/org/concordion/internal/command/VerifyRowsCommand.java
+++ b/src/main/java/org/concordion/internal/command/VerifyRowsCommand.java
@@ -3,14 +3,16 @@ package org.concordion.internal.command;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.concordion.api.*;
+import org.concordion.api.AbstractCommand;
+import org.concordion.api.CommandCall;
+import org.concordion.api.Evaluator;
+import org.concordion.api.ResultRecorder;
 import org.concordion.api.listener.VerifyRowsListener;
 import org.concordion.internal.command.strategies.DefaultMatchStrategy;
 import org.concordion.internal.command.strategies.RowsMatchStrategy;

--- a/src/main/java/org/concordion/internal/extension/ExtensionChecker.java
+++ b/src/main/java/org/concordion/internal/extension/ExtensionChecker.java
@@ -7,9 +7,11 @@ public class ExtensionChecker {
 
     private static final String MARKDOWN_EXTENSION_CLASS = "org.concordion.ext.MarkdownExtension";
     private static final String EXTENSIONS_CLASS = "org.concordion.ext.Extensions";
+    private static final String EXCEL_EXTENSION_SOURCE_CLASS = "org.concordion.ext.excel.ExcelClassPathSource";
 
     public static void checkForOutdatedExtensions() {
         checkForExtensionsNowInCore();
+        checkForBreakingChanges();
         checkForDeprecatedExtensions();
     }
 
@@ -20,6 +22,16 @@ public class ExtensionChecker {
             return; // We don't want it to be found
         }
         String msg = "The Markdown format is now supported in the main Concordion module. The concordion-markdown-extension module must be removed from the class path.";
+        throw new ConfigurationException(msg);
+    }
+
+    private static void checkForBreakingChanges() {
+        try {
+            Class.forName(EXCEL_EXTENSION_SOURCE_CLASS);
+        } catch (ClassNotFoundException expected) {
+            return; // We don't want it to be found
+        }
+        String msg = "The Concordion Excel Extension must be updated to the latest version to work with Concordion 2.0 or later.";
         throw new ConfigurationException(msg);
     }
 

--- a/src/main/java/org/concordion/internal/listener/PageFooterRenderer.java
+++ b/src/main/java/org/concordion/internal/listener/PageFooterRenderer.java
@@ -5,7 +5,6 @@ import java.util.Date;
 
 import org.concordion.api.Element;
 import org.concordion.api.Resource;
-import org.concordion.api.Target;
 import org.concordion.api.listener.SpecificationProcessingEvent;
 import org.concordion.api.listener.SpecificationProcessingListener;
 

--- a/src/main/java/org/concordion/internal/runner/DefaultConcordionRunner.java
+++ b/src/main/java/org/concordion/internal/runner/DefaultConcordionRunner.java
@@ -1,18 +1,16 @@
 package org.concordion.internal.runner;
 
+import java.util.List;
+
 import org.concordion.api.*;
-import org.concordion.internal.cache.RunResultsCache;
 import org.concordion.internal.FailFastException;
-import org.concordion.internal.FixtureType;
 import org.concordion.internal.FixtureSpecificationMapper;
+import org.concordion.internal.FixtureType;
 import org.concordion.internal.SummarizingResultRecorder;
 import org.concordion.internal.cache.ConcordionRunOutput;
+import org.concordion.internal.cache.RunResultsCache;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.notification.Failure;
-
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class DefaultConcordionRunner implements Runner {
 

--- a/src/test/java/test/concordion/internal/ClassNameBasedSpecificationLocatorTest.java
+++ b/src/test/java/test/concordion/internal/ClassNameBasedSpecificationLocatorTest.java
@@ -9,17 +9,17 @@ public class ClassNameBasedSpecificationLocatorTest extends TestCase {
 
     public void testRemovesWordTestFromEndOfClassNameAndAppendsDotHTML() throws Exception {
         SpecificationLocator locator = new ClassNameBasedSpecificationLocator();
-        assertEquals("/test/concordion/internal/ClassNameBasedSpecificationLocator.html", locator.locateSpecification(this).getPath());
+        assertEquals("/test/concordion/internal/ClassNameBasedSpecificationLocator.html", locator.locateSpecification(this, "html").getPath());
     }
 
     public void testRemovesWordFixtureFromEndOfClassNameAndAppendsDotHTML() throws Exception {
         SpecificationLocator locator = new ClassNameBasedSpecificationLocator();
         assertEquals("/spec/concordion/command/execute/ContinueAfterExceptions.html", 
-                locator.locateSpecification(new spec.concordion.command.execute.ContinueAfterExceptionsFixture()).getPath());
+                locator.locateSpecification(new spec.concordion.command.execute.ContinueAfterExceptionsFixture(), "html").getPath());
     }
 
     public void testCanAppendDotXHTMLWhenConstructedWithXHTMLArgument() throws Exception {
         SpecificationLocator locator = new ClassNameBasedSpecificationLocator("xhtml");
-        assertEquals("/test/concordion/internal/ClassNameBasedSpecificationLocator.xhtml", locator.locateSpecification(this).getPath());
+        assertEquals("/test/concordion/internal/ClassNameBasedSpecificationLocator.xhtml", locator.locateSpecification(this, "xhtml").getPath());
     }
 }


### PR DESCRIPTION
Previous 2.0 changes ensured the SpecificationLocator interface didn't change, so that we didn't break the ExcelExtension, by introducing a new SpecificationLocatorWithType interface.

However, we now have a breaking change to the Source interface, and the ExcelExtension is being updated for Concordion 2.0.
This change moves the new method from SpecificationLocatorWithType to SpecificationLocator and deprecates the existing method in SpecificationLocator. It removes the SpecificationLocatorWithType interface.

While it is a breaking change, it's much cleaner than the previous solution and more workable moving forward.
