### PR TITLE
Added spec for fail-fast on expected-to-fail example.

### DIFF
--- a/src/test/java/spec/concordion/command/example/SpecCallingFailFastExamplesFixture.java
+++ b/src/test/java/spec/concordion/command/example/SpecCallingFailFastExamplesFixture.java
@@ -1,0 +1,10 @@
+package spec.concordion.command.example;
+
+import org.concordion.integration.junit4.ConcordionRunner;
+import org.junit.runner.RunWith;
+
+import spec.concordion.results.runTotals.RunTotalsFixture;
+
+@RunWith(ConcordionRunner.class)
+public class SpecCallingFailFastExamplesFixture extends RunTotalsFixture {
+}

--- a/src/test/resources/spec/concordion/command/example/SpecCallingFailFastExamples.md
+++ b/src/test/resources/spec/concordion/command/example/SpecCallingFailFastExamples.md
@@ -1,0 +1,5 @@
+# Specification calling another with Fail Fast example 
+
+This specification calls another specification that fails fast on an example that is expected to fail.
+
+Running [FailFastExamples.html](- "#result=simulateRun(#TEXT)"), we expect [1](- "?=#result.successCount") success and [1](- "?=#result.ignoredCount") ignored.

--- a/src/test/resources/spec/concordion/command/execute/FailFastPassthrough.html
+++ b/src/test/resources/spec/concordion/command/execute/FailFastPassthrough.html
@@ -41,7 +41,7 @@
 			<span concordion:execute="#result=simulateRun('NotFailFastRunningFailFast.html')"></span>
 			If just the lower level test was annotated with <code>@FailFast</code>, we would expect
 			<span concordion:assertEquals="#result.successCount">1</span>
-			successfull command (from the higher level test) and
+			successful command (from the higher level test) and
 			<span concordion:assertEquals="#result.exceptionCount">1</span>
 			exception.
 		</p>
@@ -54,7 +54,7 @@
 			<span concordion:execute="#result=simulateRun('FailFastRunningFailFast.html')"></span>
 			If both tests are annotated with <code>@FailFast</code>, we would expect
 			<span concordion:assertEquals="#result.successCount">0</span>
-			successfull command (from the higher level test) and
+			successful command (from the higher level test) and
 			<span concordion:assertEquals="#result.exceptionCount">1</span>
 			exception.
 		</p>


### PR DESCRIPTION
Issue #144 is already fixed, this bakes in the functionality.
Also fixed typo in FailFastPassthrough spec.