### PR TITLE
Stop exception being written to console when @FailFast annotation is …

### DIFF
--- a/src/main/java/org/concordion/integration/junit4/ConcordionRunner.java
+++ b/src/main/java/org/concordion/integration/junit4/ConcordionRunner.java
@@ -165,12 +165,6 @@ public class ConcordionRunner extends BlockJUnit4ClassRunner {
         if (suiteDepth.decrementAndGet() == 0) {
             setupFixture.afterSuite();
         }
-
-        if (failFastException != null) {
-            if (setupFixture.declaresFailFast()) {
-                throw new FailFastException("Failing Fast", failFastException);
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
…used.

Fixes #164.