### PR TITLE
Example changes

### DIFF
--- a/src/main/java/org/concordion/Concordion.java
+++ b/src/main/java/org/concordion/Concordion.java
@@ -122,7 +122,14 @@ public class Concordion {
     public void finish() {
         specification.finish();
     }
-
+    
+    public void checkValidStatus(Fixture fixture) throws IOException {
+        if (getSpecification(fixture).hasExampleCommandNodes() && fixture.getDeclaredImplementationStatus() != ImplementationStatus.EXPECTED_TO_PASS) {
+            throw new IllegalStateException("Error: When the specification contains examples, "
+                    + "the Implementation Status (ExpectedToFail or Unimplemented) must be set on the example command in the specification, "
+                    + "and not as an annotation on the fixture."); 
+        }
+    }
 
     private String createMultipleSpecsMessage(Fixture fixture, SpecificationType type1, SpecificationType type2) {
         String fixturePathWithoutSuffix = fixture.getFixturePathWithoutSuffix();
@@ -143,12 +150,5 @@ public class Concordion {
         }
         msg += "'";
         return msg;
-    }
-
-    public void checkValidStatus(Fixture fixture) throws IOException {
-        if (getSpecification(fixture).hasExampleCommandNodes() && fixture.getDeclaredImplementationStatus() != ImplementationStatus.EXPECTED_TO_PASS) {
-            throw new IllegalStateException("Error: Implementation Status (ExpectedToFail or Unimplemented) must be set on the example command in the specification, "
-                    + "and not as an annotation on the fixture, when the specification contains examples."); 
-        }
     }
 }

--- a/src/main/java/org/concordion/Concordion.java
+++ b/src/main/java/org/concordion/Concordion.java
@@ -144,4 +144,11 @@ public class Concordion {
         msg += "'";
         return msg;
     }
+
+    public void checkValidStatus(Fixture fixture) throws IOException {
+        if (getSpecification(fixture).hasExampleCommandNodes() && fixture.getDeclaredImplementationStatus() != ImplementationStatus.EXPECTED_TO_PASS) {
+            throw new IllegalStateException("Error: Implementation Status (ExpectedToFail or Unimplemented) must be set on the example command in the specification, "
+                    + "and not as an annotation on the fixture, when the specification contains examples."); 
+        }
+    }
 }

--- a/src/main/java/org/concordion/api/SpecificationByExample.java
+++ b/src/main/java/org/concordion/api/SpecificationByExample.java
@@ -17,6 +17,12 @@ public interface SpecificationByExample extends Specification {
 	 */
     void setFixture(Fixture fixture);
 
+    /**
+     * Returns whether the specification contains example nodes.
+     * 
+     * @return true if specification has one or more nodes with an example command on
+     */
+    boolean hasExampleCommandNodes();
 
     /**
      * Gets all the examples in the specification.

--- a/src/main/java/org/concordion/integration/junit4/ConcordionRunner.java
+++ b/src/main/java/org/concordion/integration/junit4/ConcordionRunner.java
@@ -60,6 +60,8 @@ public class ConcordionRunner extends BlockJUnit4ClassRunner {
         concordion = fixtureRunner.getConcordion();
 
         try {
+            concordion.checkValidStatus(setupFixture);
+            
             List<String> examples = concordion.getExampleNames(setupFixture);
 
             verifyUniqueExampleMethods(examples);

--- a/src/main/java/org/concordion/internal/SpecificationToSpecificationByExampleAdaptor.java
+++ b/src/main/java/org/concordion/internal/SpecificationToSpecificationByExampleAdaptor.java
@@ -36,4 +36,9 @@ public class SpecificationToSpecificationByExampleAdaptor implements Specificati
         list.add(testDescription);
         return list;
     }
+
+    @Override
+    public boolean hasExampleCommandNodes() {
+        return false;
+    }
 }

--- a/src/main/java/org/concordion/internal/XMLSpecification.java
+++ b/src/main/java/org/concordion/internal/XMLSpecification.java
@@ -89,7 +89,7 @@ public class XMLSpecification implements SpecificationByExample {
     }
 
     public void setFixture(Fixture fixture) {
-        if (hasExamples()) {
+        if (hasExampleCommandNodes()) {
             testDescription = OUTER_EXAMPLE_NAME;
         } else {
             testDescription = fixture.getSpecificationDescription();
@@ -110,7 +110,8 @@ public class XMLSpecification implements SpecificationByExample {
         }
     }
 
-    private boolean hasExamples() {
+    @Override
+    public boolean hasExampleCommandNodes() {
         return examples.size() > 0;
     }
 

--- a/src/main/java/org/concordion/internal/XMLSpecification.java
+++ b/src/main/java/org/concordion/internal/XMLSpecification.java
@@ -119,11 +119,18 @@ public class XMLSpecification implements SpecificationByExample {
 
         List<String> commands = new ArrayList<String>();
 
-        // Add the main spec first to increase the chance that it will be run first by jUnit.
-        commands.add(testDescription);
+        if (hasNonExampleChildren(rootCommandNode)) {
+            // Add the main spec first to increase the chance that it will be run first by jUnit.
+            commands.add(testDescription);
+        }
 
         for (CommandCall exampleCall: examples) {
             commands.add(makeJunitTestName(exampleCall));
+        }
+
+        // If there are no examples and no commands, let's add the outer test so you have 1 test in the fixture
+        if (commands.isEmpty()) {
+            commands.add(testDescription);
         }
 
         return commands;

--- a/src/main/java/org/concordion/internal/cache/RunResultsCache.java
+++ b/src/main/java/org/concordion/internal/cache/RunResultsCache.java
@@ -128,9 +128,10 @@ public enum RunResultsCache {
             fixtureTotalResults = new ConcordionRunOutput(actualResultSummary, modifiedResultSummary);
             map.put(getID(fixture, null), fixtureTotalResults);
         } else {
-            addResults((SummarizingResultRecorder) fixtureTotalResults.getActualResultSummary(), actualResultSummary);
-            addResults((SummarizingResultRecorder) fixtureTotalResults.getModifiedResultSummary(), modifiedResultSummary);
-        }
+            ResultSummary totalActualResults = addResults(fixtureTotalResults.getActualResultSummary(), actualResultSummary);
+            fixtureTotalResults.setActualResultSummary(totalActualResults);
+            ResultSummary totalModifiedResults = addResults(fixtureTotalResults.getModifiedResultSummary(), modifiedResultSummary);
+            fixtureTotalResults.setModifiedResultSummary(totalModifiedResults);                  }
     }
 
     private ResultSummary clone(ResultSummary resultSummary) {
@@ -139,12 +140,17 @@ public enum RunResultsCache {
         return clone;
     }
 
-    private void addResults(SummarizingResultRecorder accumulator, ResultSummary resultsToAdd) {
-//        if (resultsToAdd.isForExample()) {
-//            accumulator.record(new SingleResultSummary(resultsToAdd));
-//        } else {
-            accumulator.record(resultsToAdd);
-//        }
+
+    private ResultSummary addResults(ResultSummary accumulator, ResultSummary resultsToAdd) {
+        SummarizingResultRecorder recorder;
+        if (accumulator instanceof SummarizingResultRecorder) {
+            recorder = (SummarizingResultRecorder) accumulator;
+        } else {
+            recorder = new SummarizingResultRecorder();
+            recorder.record(accumulator);
+        }
+        recorder.record(resultsToAdd);
+        return recorder;
     }
 
     private ConcordionRunOutput getExampleFromCache(Fixture fixture, String example) {

--- a/src/main/java/org/concordion/internal/cache/RunResultsCache.java
+++ b/src/main/java/org/concordion/internal/cache/RunResultsCache.java
@@ -6,7 +6,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.concordion.api.Fixture;
 import org.concordion.api.ResultSummary;
 import org.concordion.internal.SummarizingResultRecorder;
-import org.concordion.internal.XMLSpecification;
 
 /**
  * A thread-safe class to provide caching of run results.

--- a/src/main/java/org/concordion/internal/command/RunCommand.java
+++ b/src/main/java/org/concordion/internal/command/RunCommand.java
@@ -93,9 +93,12 @@ public class RunCommand extends AbstractCommand {
     /* For non-html format specs, update the href to reference the html output */
     private void updateHrefSuffix(Element element, String href) {
         if (!(href.endsWith(".html"))) {
-            String modifiedHref = href.substring(0, href.lastIndexOf(".")) + ".html";
-            element.removeAttribute("href");
-            element.addAttribute("href", modifiedHref);
+            int dot = href.lastIndexOf(".");
+            if (dot > 0) {
+                String modifiedHref = href.substring(0, dot) + ".html";
+                element.removeAttribute("href");
+                element.addAttribute("href", modifiedHref);
+            }
         }
     }
 

--- a/src/test-dummies/java/spec/concordion/command/example/ExamplesMarkedExpectedToFailFixture.java
+++ b/src/test-dummies/java/spec/concordion/command/example/ExamplesMarkedExpectedToFailFixture.java
@@ -1,0 +1,8 @@
+package spec.concordion.command.example;
+
+import org.concordion.integration.junit4.ConcordionRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(ConcordionRunner.class)
+public class ExamplesMarkedExpectedToFailFixture {
+}

--- a/src/test-dummies/java/spec/concordion/command/example/ExamplesMarkedUnimplementedFixture.java
+++ b/src/test-dummies/java/spec/concordion/command/example/ExamplesMarkedUnimplementedFixture.java
@@ -1,0 +1,8 @@
+package spec.concordion.command.example;
+
+import org.concordion.integration.junit4.ConcordionRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(ConcordionRunner.class)
+public class ExamplesMarkedUnimplementedFixture {
+}

--- a/src/test-dummies/java/spec/concordion/results/runTotals/ExpectedToFailWithExampleFixture.java
+++ b/src/test-dummies/java/spec/concordion/results/runTotals/ExpectedToFailWithExampleFixture.java
@@ -1,0 +1,10 @@
+package spec.concordion.results.runTotals;
+
+import org.concordion.api.ExpectedToFail;
+import org.concordion.integration.junit4.ConcordionRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(ConcordionRunner.class)
+@ExpectedToFail
+public class ExpectedToFailWithExampleFixture {
+}

--- a/src/test-dummies/resources/spec/concordion/command/example/ExamplesMarkedExpectedToFail.html
+++ b/src/test-dummies/resources/spec/concordion/command/example/ExamplesMarkedExpectedToFail.html
@@ -1,0 +1,28 @@
+<html xmlns:c="http://www.concordion.org/2007/concordion">
+<link href="../../../../concordion.css" rel="stylesheet" type="text/css" />
+<body>
+
+
+<div c:example="example-1" c:status="ExpectedToFail">
+    <h3>Unimplemented example marked as ExpectedToFail</h3>
+    <ul>
+        <li>No assertions here!</li>
+    </ul>
+</div>
+
+<div c:example="example-2" c:status="ExpectedToFail">
+    <h3>Failing example marked as ExpectedToFail</h3>
+    <ul>
+        <li><span c:assertTrue="false">Fail</span></li>
+    </ul>
+</div>
+
+<div c:example="example-3" c:status="ExpectedToFail">
+    <h3>Passing example marked as ExpectedToFail</h3>
+    <ul>
+        <li><span c:assertTrue="true">Pass</span></li>
+    </ul>
+</div>
+
+</body>
+</html>

--- a/src/test-dummies/resources/spec/concordion/command/example/ExamplesMarkedUnimplemented.html
+++ b/src/test-dummies/resources/spec/concordion/command/example/ExamplesMarkedUnimplemented.html
@@ -1,0 +1,31 @@
+<html xmlns:c="http://www.concordion.org/2007/concordion">
+<link href="../../../../concordion.css" rel="stylesheet" type="text/css" />
+<body>
+
+
+<div c:example="example-1" c:status="Unimplemented">
+    <h3>Example marked as Unimplemented</h3>
+    <ul>
+        <li>No assertions here!</li>
+    </ul>
+
+</div>
+
+<div c:example="example-2" c:status="Unimplemented">
+    <h3>Example marked as Unimplemented but has passing assertion</h3>
+    <ul>
+        <li>Oops, I made a successful <span c:assertTrue="true">assertion</span></li>
+    </ul>
+
+</div>
+
+<div c:example="example-3" c:status="Unimplemented">
+    <h3>Example marked as Unimplemented but has failing assertion</h3>
+    <ul>
+        <li>Oops, I made a failing <span c:assertTrue="false">assertion</span></li>
+    </ul>
+
+</div>
+
+</body>
+</html>

--- a/src/test-dummies/resources/spec/concordion/results/runTotals/ExpectedToFailWithExample.md
+++ b/src/test-dummies/resources/spec/concordion/results/runTotals/ExpectedToFailWithExample.md
@@ -1,0 +1,14 @@
+# Expected To Fail with Example
+
+The fixture implementation status (`@ExpectedToFail` and `@Unimplemented`) is only supported when there are no example commands in the specification.
+
+Since the fixture implementation status is checked at the JUnit test level, it does not makes sense to apply it when there are multiple examples.
+
+When there are example commands in the specification, they can use the "status" attribute on the example command to set the implementation status of the example.
+
+See https://github.com/concordion/concordion/issues/189.
+
+[Should fail](- "c:assertTrue=false")
+
+# [Example 1](-)
+[Success](- "c:assertTrue=true")

--- a/src/test/java/spec/concordion/command/example/FixtureWithExampleHookMethodsFixture.java
+++ b/src/test/java/spec/concordion/command/example/FixtureWithExampleHookMethodsFixture.java
@@ -1,0 +1,33 @@
+package spec.concordion.command.example;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.concordion.api.AfterExample;
+import org.concordion.api.BeforeExample;
+import org.concordion.integration.junit4.ConcordionRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(ConcordionRunner.class)
+public class FixtureWithExampleHookMethodsFixture {
+
+    private static AtomicInteger staticBeforeExampleCounter = new AtomicInteger();
+    private static AtomicInteger staticAfterExampleCounter = new AtomicInteger();
+    
+    @BeforeExample
+    private void beforeEachExample() {
+        staticBeforeExampleCounter.incrementAndGet();
+    }
+    
+    @AfterExample
+    private void afterEachExample() {
+        staticAfterExampleCounter.incrementAndGet();
+    }
+    
+    public int getBeforeExampleCounter() {
+        return staticBeforeExampleCounter.get();
+    }
+
+    public int getAfterExampleCounter() {
+        return staticAfterExampleCounter.get();
+    }
+}

--- a/src/test/java/spec/concordion/command/example/FixtureWithExampleInitialisationFixture.java
+++ b/src/test/java/spec/concordion/command/example/FixtureWithExampleInitialisationFixture.java
@@ -8,15 +8,15 @@ import org.junit.runner.RunWith;
 @RunWith(ConcordionRunner.class)
 public class FixtureWithExampleInitialisationFixture {
 
-    private static AtomicInteger staticCounter = new AtomicInteger();
+    private static AtomicInteger staticFieldCounter = new AtomicInteger();
     
     private int counter = incrementOnEachCall();
 
     private int incrementOnEachCall() {
-        return staticCounter.incrementAndGet();
+        return staticFieldCounter.incrementAndGet();
     }
-
-    public int getCounter() {
+    
+    public int getFieldInitialisationCounter() {
         return counter;
     }
 }

--- a/src/test/java/spec/concordion/command/example/FixtureWithExampleWithoutOuterExampleHookMethodsFixture.java
+++ b/src/test/java/spec/concordion/command/example/FixtureWithExampleWithoutOuterExampleHookMethodsFixture.java
@@ -1,0 +1,33 @@
+package spec.concordion.command.example;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.concordion.api.AfterExample;
+import org.concordion.api.BeforeExample;
+import org.concordion.integration.junit4.ConcordionRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(ConcordionRunner.class)
+public class FixtureWithExampleWithoutOuterExampleHookMethodsFixture {
+
+    private static AtomicInteger staticBeforeExampleCounter = new AtomicInteger();
+    private static AtomicInteger staticAfterExampleCounter = new AtomicInteger();
+    
+    @BeforeExample
+    private void beforeEachExample() {
+        staticBeforeExampleCounter.incrementAndGet();
+    }
+    
+    @AfterExample
+    private void afterEachExample() {
+        staticAfterExampleCounter.incrementAndGet();
+    }
+    
+    public int getBeforeExampleCounter() {
+        return staticBeforeExampleCounter.get();
+    }
+
+    public int getAfterExampleCounter() {
+        return staticAfterExampleCounter.get();
+    }
+}

--- a/src/test/java/spec/concordion/command/example/FixtureWithExampleWithoutOuterExampleInitialisationFixture.java
+++ b/src/test/java/spec/concordion/command/example/FixtureWithExampleWithoutOuterExampleInitialisationFixture.java
@@ -6,7 +6,7 @@ import org.concordion.integration.junit4.ConcordionRunner;
 import org.junit.runner.RunWith;
 
 @RunWith(ConcordionRunner.class)
-public class FixtureWithoutExampleInitialisationFixture {
+public class FixtureWithExampleWithoutOuterExampleInitialisationFixture {
 
     private static AtomicInteger staticFieldCounter = new AtomicInteger();
     

--- a/src/test/java/spec/concordion/command/example/FixtureWithoutExampleHookMethodsFixture.java
+++ b/src/test/java/spec/concordion/command/example/FixtureWithoutExampleHookMethodsFixture.java
@@ -1,0 +1,33 @@
+package spec.concordion.command.example;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.concordion.api.AfterExample;
+import org.concordion.api.BeforeExample;
+import org.concordion.integration.junit4.ConcordionRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(ConcordionRunner.class)
+public class FixtureWithoutExampleHookMethodsFixture {
+
+    private static AtomicInteger staticBeforeExampleCounter = new AtomicInteger();
+    private static AtomicInteger staticAfterExampleCounter = new AtomicInteger();
+    
+    @BeforeExample
+    private void beforeEachExample() {
+        staticBeforeExampleCounter.incrementAndGet();
+    }
+    
+    @AfterExample
+    private void afterEachExample() {
+        staticAfterExampleCounter.incrementAndGet();
+    }
+    
+    public int getBeforeExampleCounter() {
+        return staticBeforeExampleCounter.get();
+    }
+
+    public int getAfterExampleCounter() {
+        return staticAfterExampleCounter.get();
+    }
+}

--- a/src/test/resources/spec/concordion/annotation/ImplementationStatus.html
+++ b/src/test/resources/spec/concordion/annotation/ImplementationStatus.html
@@ -5,6 +5,9 @@
 <body>
 
   <h1>Implementation Status</h1>
+  
+  <p><i>Since 2.0.0</i>, this annotation can only be used with specifications that are not using the example command. 
+  Specifications that are using the example command must use the "status" attribute on the example command instead.</p>  
 	
     <p>
     	To allow you to include Concordion specifications in the build before they have

--- a/src/test/resources/spec/concordion/command/example/Example.html
+++ b/src/test/resources/spec/concordion/command/example/Example.html
@@ -9,11 +9,6 @@
 
 <p>The example command also supports the <a c:run="concordion" href="../../extension/listener/ExampleListener.html">example listener</a>.</p>
 
-<p>A new fixture instance is created for each example, in keeping with the way that JUnit creates a <a href="http://martinfowler.com/bliki/JunitNewInstance.html">new instance per test</a>.
-For classes without examples, only <a c:run="concordion" href="FixtureWithoutExampleInitialisation.html">1 instance is created</a>.
-For classes with examples, <a c:run="concordion" href="FixtureWithExampleInitialisation.html">n+1 instances are created</a> where n is the number of examples.</p>  
-<p>Fixture fields can be <a c:run="concordion" href="ScopedField.html">scoped</a> for reuse across a specification, in addition to the default example scope.</p>
-
 <div c:example="before">
     <h3>Before</h3>
     <p>To specify that a piece of HTML should be run before each example, annotate the enclosing
@@ -129,6 +124,29 @@ For classes with examples, <a c:run="concordion" href="FixtureWithExampleInitial
             <span c:assertEquals="#result.exceptionCount">0</span> exceptions, and
                 <span c:assertEquals="#result.ignoredCount">0</span> ignores
     </p>
+</div>
+
+<div c:example="instances">
+<h3>Fixture Instances</h3>
+<p>A new fixture instance is created for each example, in keeping with the way that JUnit creates a <a href="http://martinfowler.com/bliki/JunitNewInstance.html">new instance per test</a>.</p>
+<ul>
+<li>For classes without examples, only <a c:run="concordion" href="FixtureWithoutExampleInitialisation.html">1 instance is created</a>.</li>
+<li>For classes with examples with commands also outside of the examples, <a c:run="concordion" href="FixtureWithExampleInitialisation.html">n+1 instances are created</a> where n is the number of examples.</li>
+<li>For classes with examples with no commands outside of the examples <a c:run="concordion" href="FixtureWithExampleWithoutOuterExampleInitialisation.html">n instances are created</a> where n is the number of examples.</li>
+</ul>  
+
+<h4>Field reuse</h4>
+<p>Fixture fields can be <a c:run="concordion" href="ScopedField.html">scoped</a> for reuse across a specification, in addition to the default example scope.</p>
+</div>
+
+<div c:example="hooks">
+<h3>Method hooks</h3>
+<p><code>@BeforeExample</code> and <code>@AfterExample</code> methods are called for each example, including the "outer" example.</p>
+<ul>
+<li>For classes without examples, the hook methods are called <a c:run="concordion" href="FixtureWithoutExampleHookMethods.html">1 time</a>.</li>
+<li>For classes with examples with commands also outside of the examples, the hook methods are called <a c:run="concordion" href="FixtureWithExampleHookMethods.html">n+1 times</a> where n is the number of examples.</li>
+<li>For classes with examples with no commands outside of the examples, the hook methods are called <a c:run="concordion" href="FixtureWithExampleWithoutOuterExampleHookMethods.html">n times</a> where n is the number of examples.</li>
+</ul>  
 </div>
 
 <div c:example="expectedToFail" c:status="ExpectedToFail">

--- a/src/test/resources/spec/concordion/command/example/Example.html
+++ b/src/test/resources/spec/concordion/command/example/Example.html
@@ -149,22 +149,29 @@
 </ul>  
 </div>
 
-<div c:example="expectedToFail" c:status="ExpectedToFail">
+<p>
+</p>
+
+<div c:example="expectedToFail">
     <h3>Expected to Fail</h3>
 
-    <p>Concordion examples can be marked as expected to <span c:assertFalse="isTrue()">fail</span>:</p>
+    <p>Concordion examples can be marked as expected to fail:</p>
 
     <code><pre>
 &lt;div concordion:example="example3" concordion:status="ExpectedToFail"&gt;
         Example goes here
 &lt;/div&gt;</pre></code>
 
-<p>In these cases, the example will return 0 success, 1 failures, 0 ignored, and 0 exceptions back to the specification
-as a whole, but the specification will still pass.</p>
-
+<p>
+A spec (<a href="ExamplesMarkedExpectedToFail.html" c:execute="#result=runTestDummySpec(#TEXT)">ExamplesMarkedExpectedToFail.html</a>)
+with an unimplemented example, a successful example and a failing example all marked as ExpectedToFail, returns <span c:assertEquals="#result.successCount">0</span> successes,
+<span c:assertEquals="#result.failureCount">2</span> failures,
+<span c:assertEquals="#result.exceptionCount">0</span> exceptions, and
+<span c:assertEquals="#result.ignoredCount">1</span> ignores.
+</p>
 </div>
 
-<div c:example="unimplemented" c:status="Unimplemented">
+<div c:example="unimplemented">
     <h3>Unimplemented</h3>
 
     <p>Concordion examples can be marked as unimplemented.</p>
@@ -176,8 +183,13 @@ as a whole, but the specification will still pass.</p>
 
     <p>Any asserts done in the example will cause the example to fail the spec.</p>
 
-    <p>In these cases, the example will return 1 success, 0 failures, 0 ignored, and 0 exceptions back to the specification
-        as a whole.</p>
+<p>
+A spec (<a href="ExamplesMarkedUnimplemented.html" c:execute="#result=runTestDummySpec(#TEXT)">ExamplesMarkedUnimplemented.html</a>)
+with an unimplemented example, a successful example and a failing example all marked as Unimplemented, returns <span c:assertEquals="#result.successCount">0</span> successes,
+<span c:assertEquals="#result.failureCount">2</span> failure,
+<span c:assertEquals="#result.exceptionCount">0</span> exceptions, and
+<span c:assertEquals="#result.ignoredCount">1</span> ignores.
+</p>
 
 </div>
 

--- a/src/test/resources/spec/concordion/command/example/FixtureWithExampleHookMethods.html
+++ b/src/test/resources/spec/concordion/command/example/FixtureWithExampleHookMethods.html
@@ -1,0 +1,29 @@
+<html xmlns:c="http://www.concordion.org/2007/concordion">
+<link href="../../../../concordion.css" rel="stylesheet" type="text/css" />
+<body>
+
+<h1>Hook methods in fixtures with examples</h1>
+
+<p>Since this part of the specification is in the outer example (ie. outside of the named examples)
+ and the @BeforeExample and @AfterExample hook methods are called for the outer example,
+the @BeforeExample methods should have been called <span c:assertEquals="getBeforeExampleCounter()">1</span> time and 
+the @AfterExample methods called <span c:assertEquals="getAfterExampleCounter()">0</span> times.</p>
+
+<div c:example="example1">
+<p>Since this part of the specification is in the first example,
+the @BeforeExample methods should have been called <span c:assertEquals="getBeforeExampleCounter()">2</span> times and 
+the @AfterExample methods called <span c:assertEquals="getAfterExampleCounter()">1</span> time.</p>
+</div>
+
+<div c:example="example2">
+<p>Since this part of the specification is in the second example, 
+the @BeforeExample methods should have been called <span c:assertEquals="getBeforeExampleCounter()">3</span> times and 
+the @AfterExample methods called <span c:assertEquals="getAfterExampleCounter()">2</span> times.</p>
+</div>
+
+<p>Since this part of the specification is in the outer example, it is executed before the named examples above, 
+the @BeforeExample methods should have been called <span c:assertEquals="getBeforeExampleCounter()">1</span> time and 
+the @AfterExample methods called <span c:assertEquals="getAfterExampleCounter()">0</span> times.</p>
+
+</body>
+</html>

--- a/src/test/resources/spec/concordion/command/example/FixtureWithExampleInitialisation.html
+++ b/src/test/resources/spec/concordion/command/example/FixtureWithExampleInitialisation.html
@@ -2,20 +2,22 @@
 <link href="../../../../concordion.css" rel="stylesheet" type="text/css" />
 <body>
 
-<h1>Field Initialisation in Fixtures With Examples</h1>
+<h1>Field initialisation in fixtures with examples</h1>
 
-<p>When running a specification with examples, a new fixture object is created for each example, including the outer (anonymous) example.</p>
-<p>Since this part of the specification is in the outer example, the instance fields should have been created <span c:assertEquals="getCounter()">1</span> time.</p>
+<p>When running a specification with examples, a new fixture object is created for each example, including the outer (anonymous) example, if there is one.</p>
+<p>Since this part of the specification is in the outer example (ie. outside of the named examples), 
+the instance fields should have been created <span c:assertEquals="getFieldInitialisationCounter()">1</span> time.</p>
 
 <div c:example="example1">
-<p>Since this part of the specification is in the first example, the instance fields should have been created <span c:assertEquals="getCounter()">2</span> times.</p>
+<p>Since this part of the specification is in the first example, the instance fields should have been created <span c:assertEquals="getFieldInitialisationCounter()">2</span> times.</p>
 </div>
 
 <div c:example="example2">
-<p>Since this part of the specification is in the second example, the instance fields should have been created <span c:assertEquals="getCounter()">3</span> times.</p>
+<p>Since this part of the specification is in the second example, the instance fields should have been created <span c:assertEquals="getFieldInitialisationCounter()">3</span> times.</p>
 </div>
 
-<p>Since this part of the specification is in the outer example, the instance fields should have been created <span c:assertEquals="getCounter()">1</span> time.</p>
+<p>Since this part of the specification is in the outer example, it is executed before the named examples above,
+the instance fields should have been created <span c:assertEquals="getFieldInitialisationCounter()">1</span> time.</p>
 
 </body>
 </html>

--- a/src/test/resources/spec/concordion/command/example/FixtureWithExampleWithoutOuterExampleHookMethods.html
+++ b/src/test/resources/spec/concordion/command/example/FixtureWithExampleWithoutOuterExampleHookMethods.html
@@ -1,0 +1,19 @@
+<html xmlns:c="http://www.concordion.org/2007/concordion">
+<link href="../../../../concordion.css" rel="stylesheet" type="text/css" />
+<body>
+
+<h1>Hook Methods in fixtures with examples, but nothing in the "outer" example</h1>
+
+<p>Unlike the "Hook Methods in fixtures with examples" specification, this specification has no commands outside of the named examples.</p>
+
+<div c:example="example1">
+<p>Since this part of the specification is in the first example and there is no "outer" example, the @BeforeExample methods should have been called <span c:assertEquals="getBeforeExampleCounter()">1</span> time,
+and the @AfterExample methods should have been called <span c:assertEquals="getAfterExampleCounter()">0</span> time.</p>
+</div>
+
+<div c:example="example2">
+<p>Since this part of the specification is in the second example, the @BeforeExample methods should have been called <span c:assertEquals="getBeforeExampleCounter()">2</span> times,
+and the @AfterExample methods should have been called <span c:assertEquals="getAfterExampleCounter()">1</span> times.</p>
+</div>
+</body>
+</html>

--- a/src/test/resources/spec/concordion/command/example/FixtureWithExampleWithoutOuterExampleInitialisation.html
+++ b/src/test/resources/spec/concordion/command/example/FixtureWithExampleWithoutOuterExampleInitialisation.html
@@ -4,15 +4,14 @@
 
 <h1>Field initialisation in fixtures with examples, but nothing in the "outer" example</h1>
 
-<p>Unlike the "Field initialisation in fixtures with examples" specification, this specification has no commands outside of the named
-examples.</p>
+<p>Unlike the "Field initialisation in fixtures with examples" specification, this specification has no commands outside of the named examples.</p>
 
 <div c:example="example1">
-<p>Since this part of the specification is in the first example and there is no "outer" example, the instance fields should have been created <span c:assertEquals="getCounter()">1</span> times.</p>
+<p>Since this part of the specification is in the first example and there is no "outer" example, the instance fields should have been created <span c:assertEquals="getFieldInitialisationCounter()">1</span> times.</p>
 </div>
 
 <div c:example="example2">
-<p>Since this part of the specification is in the second example, the instance fields should have been created <span c:assertEquals="getCounter()">2</span> times.</p>
+<p>Since this part of the specification is in the second example, the instance fields should have been created <span c:assertEquals="getFieldInitialisationCounter()">2</span> times.</p>
 </div>
 </body>
 </html>

--- a/src/test/resources/spec/concordion/command/example/FixtureWithExampleWithoutOuterExampleInitialisation.html
+++ b/src/test/resources/spec/concordion/command/example/FixtureWithExampleWithoutOuterExampleInitialisation.html
@@ -1,0 +1,18 @@
+<html xmlns:c="http://www.concordion.org/2007/concordion">
+<link href="../../../../concordion.css" rel="stylesheet" type="text/css" />
+<body>
+
+<h1>Field initialisation in fixtures with examples, but nothing in the "outer" example</h1>
+
+<p>Unlike the "Field initialisation in fixtures with examples" specification, this specification has no commands outside of the named
+examples.</p>
+
+<div c:example="example1">
+<p>Since this part of the specification is in the first example and there is no "outer" example, the instance fields should have been created <span c:assertEquals="getCounter()">1</span> times.</p>
+</div>
+
+<div c:example="example2">
+<p>Since this part of the specification is in the second example, the instance fields should have been created <span c:assertEquals="getCounter()">2</span> times.</p>
+</div>
+</body>
+</html>

--- a/src/test/resources/spec/concordion/command/example/FixtureWithoutExampleHookMethods.html
+++ b/src/test/resources/spec/concordion/command/example/FixtureWithoutExampleHookMethods.html
@@ -1,0 +1,15 @@
+<html xmlns:c="http://www.concordion.org/2007/concordion">
+<link href="../../../../concordion.css" rel="stylesheet" type="text/css" />
+<body>
+
+<h1>Hook Methods in Fixtures</h1>
+
+<p>When running a specification without examples, the specification is run as a single "outer" example
+ and the @BeforeExample and @AfterExample hook methods are called for this outer example.
+</p>
+<p>The @BeforeExample methods should have been called <span c:assertEquals="getBeforeExampleCounter()">1</span> time,
+and the @AfterExample methods should have been called <span c:assertEquals="getAfterExampleCounter()">0</span> times.
+</p> 
+
+</body>
+</html>

--- a/src/test/resources/spec/concordion/command/example/FixtureWithoutExampleInitialisation.html
+++ b/src/test/resources/spec/concordion/command/example/FixtureWithoutExampleInitialisation.html
@@ -4,7 +4,7 @@
 
 <h1>Field Initialisation in Fixtures</h1>
 
-<p>When running a specification without examples, fields should only be created <span c:assertEquals="getCounter()">1</span> time.</p>
+<p>When running a specification without examples, fields should only be created <span c:assertEquals="getFieldInitialisationCounter()">1</span> time.</p>
 
 </body>
 </html>

--- a/src/test/resources/spec/concordion/results/runTotals/RunTotals.html
+++ b/src/test/resources/spec/concordion/results/runTotals/RunTotals.html
@@ -146,7 +146,7 @@
         <tr>
             <td>Test the case where an exception is caused since a file is expected to fail but has examples</td>
             <td><a href="ExpectedToFailWithExample.html">ExpectedToFailWithExample.html</a></td>
-            <td>Yes</td>
+            <td>No</td>
             <td>0</td>
             <td>0</td>
             <td>1</td>

--- a/src/test/resources/spec/concordion/results/runTotals/RunTotals.html
+++ b/src/test/resources/spec/concordion/results/runTotals/RunTotals.html
@@ -143,6 +143,17 @@
 			<td>Successes: 0, Failures: 0, Ignored: 1</td>
 		</tr>
 
+        <tr>
+            <td>Test the case where an exception is caused since a file is expected to fail but has examples</td>
+            <td><a href="ExpectedToFailWithExample.html">ExpectedToFailWithExample.html</a></td>
+            <td>Yes</td>
+            <td>0</td>
+            <td>0</td>
+            <td>1</td>
+            <td>0</td>
+            <td>Successes: 0, Failures: 0, Exceptions: 1</td>
+        </tr>
+
 		<tr>
 			<td>Test that the JUnit annotations work when performing a concordion:run command</td>
 			<td><a href="Annotations.html">Annotations.html</a></td>


### PR DESCRIPTION
* Don't run a separate "outer" example if there are no Concordion commands outside of named examples (#187)
* Don't allow ExpectedToFail or Unimplemented annotations on fixtures where the specification has named examples (#189)
* Fix ExpectedToFail annotation causes ClassCastException in RunResultsCache.addResults() (#188)
* Create extra specifications, and move ExpectedToFail example from Example spec to a linked test-dummies spec, so that Example spec is now green rather than grey