### PR TITLE
Restructure result recording

### DIFF
--- a/src/main/java/org/concordion/Concordion.java
+++ b/src/main/java/org/concordion/Concordion.java
@@ -15,13 +15,14 @@ public class Concordion {
     private final SpecificationReader specificationReader;
     private Resource resource;
     private SpecificationByExample specification;
+    private String specificationDescription;
 
     /**
      * @deprecated use {@link #Concordion(List, SpecificationLocator, SpecificationReader, EvaluatorFactory, Fixture)} instead
      * @param specificationLocator locates the specification based on the specification type
      * @param specificationReader specification reader
      * @param evaluatorFactory evaluator factory
-     * @param fixture fixture instance 
+     * @param fixture fixture instance
      * @throws IOException on i/o error
      */
     @Deprecated
@@ -33,14 +34,14 @@ public class Concordion {
     }
 
     /**
-     * Constructor. Locates the specification with a type from the <code>specificationTypes</code> list. 
-     * Errors if unable to find exactly one specification of all the specified types. 
-     * 
+     * Constructor. Locates the specification with a type from the <code>specificationTypes</code> list.
+     * Errors if unable to find exactly one specification of all the specified types.
+     *
      * @param specificationTypes a list of types that this Concordion instance will check for (eg. html, md), with a converter for each type
      * @param specificationLocator locates the specification based on the specification type
      * @param specificationReader specification reader
      * @param evaluatorFactory evaluator factory
-     * @param fixture fixture instance 
+     * @param fixture fixture instance
      * @throws IOException on i/o error
      */
     public Concordion(List<SpecificationType> specificationTypes, SpecificationLocator specificationLocator, SpecificationReader specificationReader, EvaluatorFactory evaluatorFactory, Fixture fixture) throws IOException {
@@ -64,16 +65,16 @@ public class Concordion {
         }
         specificationReader.setSpecificationConverter(specificationType.getConverter());
     }
-    
-    /** 
+
+    /**
      * For TestRig use only
      * @param resource test resource to override the specification resource with
-     * @throws IOException on i/o error 
+     * @throws IOException on i/o error
      */
     public void override(Resource resource) throws IOException {
         this.resource = resource;
     }
- 
+
     public ResultSummary process(Fixture fixture) throws IOException {
         SummarizingResultRecorder resultRecorder = new SummarizingResultRecorder();
         resultRecorder.setSpecificationDescription(fixture.getSpecificationDescription());
@@ -84,12 +85,17 @@ public class Concordion {
     private SpecificationByExample getSpecification(Fixture fixture) throws IOException {
         if (specification == null) {
             specification = loadSpecificationFromResource(fixture, resource);
+            specificationDescription = specification.getSpecificationDescription();
         }
         return specification;
     }
 
     public List<String> getExampleNames(Fixture fixture) throws IOException {
         return getSpecification(fixture).getExampleNames();
+    }
+
+    public boolean hasExampleCommands(Fixture fixture) throws IOException {
+        return getSpecification(fixture).hasExampleCommandNodes();
     }
 
     public ResultSummary processExample(Fixture fixture, String example) throws IOException {
@@ -122,12 +128,12 @@ public class Concordion {
     public void finish() {
         specification.finish();
     }
-    
+
     public void checkValidStatus(Fixture fixture) throws IOException {
         if (getSpecification(fixture).hasExampleCommandNodes() && fixture.getDeclaredImplementationStatus() != ImplementationStatus.EXPECTED_TO_PASS) {
             throw new IllegalStateException("Error: When the specification contains examples, "
                     + "the Implementation Status (ExpectedToFail or Unimplemented) must be set on the example command in the specification, "
-                    + "and not as an annotation on the fixture."); 
+                    + "and not as an annotation on the fixture.");
         }
     }
 
@@ -150,5 +156,9 @@ public class Concordion {
         }
         msg += "'";
         return msg;
+    }
+
+    public String getSpecificationDescription() {
+        return specificationDescription;
     }
 }

--- a/src/main/java/org/concordion/api/SpecificationByExample.java
+++ b/src/main/java/org/concordion/api/SpecificationByExample.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 /**
  * Extension interface for {@link Specification}s that contain Concordion examples.
- * 
+ *
  * @since 2.0.0
  */
 public interface SpecificationByExample extends Specification {
@@ -12,28 +12,35 @@ public interface SpecificationByExample extends Specification {
 	/**
 	 * Sets the fixture. Will be called before the other methods are called so that
 	 * the class can process the fixture to determine examples, etc.
-	 * 
+	 *
 	 * @param fixture the fixture instance
 	 */
     void setFixture(Fixture fixture);
 
     /**
      * Returns whether the specification contains example nodes.
-     * 
+     *
      * @return true if specification has one or more nodes with an example command on
      */
     boolean hasExampleCommandNodes();
 
     /**
+     * Gets the description of the exported specification.
+     *
+     * @return specification description
+     */
+    String getSpecificationDescription();
+
+    /**
      * Gets all the examples in the specification.
-     * 
+     *
      * @return names of the examples
      */
     List<String> getExampleNames();
-    
+
     /**
      * Processes a single example.
-     * 
+     *
      * @param evaluator evaluator
      * @param example name of the example
      * @param resultRecorder result recorder

--- a/src/main/java/org/concordion/integration/junit4/ConcordionRunner.java
+++ b/src/main/java/org/concordion/integration/junit4/ConcordionRunner.java
@@ -204,7 +204,6 @@ public class ConcordionRunner extends BlockJUnit4ClassRunner {
             result.assertIsSatisfied(fixture);
 
         } catch (ConcordionAssertionError e) {
-            throw e;
         } catch (FailFastException e){
             failFastException = e;
             throw e;

--- a/src/main/java/org/concordion/integration/junit4/ConcordionRunner.java
+++ b/src/main/java/org/concordion/integration/junit4/ConcordionRunner.java
@@ -11,7 +11,7 @@ import org.concordion.Concordion;
 import org.concordion.api.Fixture;
 import org.concordion.api.ResultSummary;
 import org.concordion.internal.*;
-import org.concordion.internal.cache.ConcordionRunOutput;
+import org.concordion.internal.RunOutput;
 import org.concordion.internal.cache.RunResultsCache;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
@@ -21,6 +21,8 @@ import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 
 public class ConcordionRunner extends BlockJUnit4ClassRunner {
+
+    private final RunResultsCache runResultsCache = RunResultsCache.SINGLETON;
 
     // this sort of thing is so much easier with Java 8!
     public ConcordionFrameworkMethod.ConcordionRunnerInterface concordionRunnerInterface =
@@ -133,11 +135,11 @@ public class ConcordionRunner extends BlockJUnit4ClassRunner {
         try {
             // we figure out if the spec has been run before by checking if there are any
             // prior results in the cache
-            boolean firstRun = null ==RunResultsCache.SINGLETON.getFromCache(fixtureClass, null);
+            boolean firstRun = null == runResultsCache.getFromCache(fixtureClass, null);
 
             // only setup the fixture if it hasn't been run before
             if (firstRun) {
-                RunResultsCache.SINGLETON.startSpecificationRun(setupFixture, concordion.getSpecificationDescription());
+                runResultsCache.startFixtureRun(setupFixture, concordion.getSpecificationDescription());
                 setupFixture.beforeSpecification();
             }
 
@@ -149,7 +151,7 @@ public class ConcordionRunner extends BlockJUnit4ClassRunner {
                 concordion.finish();
             }
 
-            ConcordionRunOutput results = RunResultsCache.SINGLETON.getFromCache(fixtureClass, null);
+            RunOutput results = runResultsCache.getFromCache(fixtureClass, null);
 
             if (results != null) {
                 synchronized (System.out) {

--- a/src/main/java/org/concordion/integration/junit4/ConcordionRunner.java
+++ b/src/main/java/org/concordion/integration/junit4/ConcordionRunner.java
@@ -61,7 +61,7 @@ public class ConcordionRunner extends BlockJUnit4ClassRunner {
 
         try {
             concordion.checkValidStatus(setupFixture);
-            
+
             List<String> examples = concordion.getExampleNames(setupFixture);
 
             verifyUniqueExampleMethods(examples);
@@ -137,6 +137,7 @@ public class ConcordionRunner extends BlockJUnit4ClassRunner {
 
             // only setup the fixture if it hasn't been run before
             if (firstRun) {
+                RunResultsCache.SINGLETON.startSpecificationRun(setupFixture, concordion.getSpecificationDescription());
                 setupFixture.beforeSpecification();
             }
 

--- a/src/main/java/org/concordion/internal/FixtureRunner.java
+++ b/src/main/java/org/concordion/internal/FixtureRunner.java
@@ -102,6 +102,7 @@ public class FixtureRunner {
         if (results == null) {
             concordion.finish();
         }
+        resultSummary.print(System.out, fixture);
         return resultSummary;
     }
 }

--- a/src/main/java/org/concordion/internal/FixtureRunner.java
+++ b/src/main/java/org/concordion/internal/FixtureRunner.java
@@ -4,27 +4,24 @@ import org.concordion.Concordion;
 import org.concordion.api.Fixture;
 import org.concordion.api.ResultSummary;
 import org.concordion.internal.cache.RunResultsCache;
-import org.concordion.internal.cache.ConcordionRunOutput;
 import org.concordion.internal.extension.FixtureExtensionLoader;
 
 import java.io.IOException;
 
 public class FixtureRunner {
     private static RunResultsCache runResultsCache = RunResultsCache.SINGLETON;
-    private final FixtureExtensionLoader fixtureExtensionLoader = new FixtureExtensionLoader();
-    private final FixtureOptionsLoader fixtureOptionsLoader = new FixtureOptionsLoader();
     private Concordion concordion;
 
     public FixtureRunner(Fixture fixture) throws UnableToBuildConcordionException {
         ConcordionBuilder concordionBuilder = new ConcordionBuilder().withFixture(fixture);
-        fixtureExtensionLoader.addExtensions(fixture, concordionBuilder);
-        fixtureOptionsLoader.addOptions(fixture, concordionBuilder);
+        new FixtureExtensionLoader().addExtensions(fixture, concordionBuilder);
+        new FixtureOptionsLoader().addOptions(fixture, concordionBuilder);
         concordion = concordionBuilder.build();
     }
 
     public ResultSummary run(String example, Fixture fixture) throws IOException {
 
-    	ConcordionRunOutput runOutput = runResultsCache.startRun(fixture, example);
+        RunOutput runOutput = runResultsCache.startRun(fixture, example);
         ResultSummary actualResultSummary = runOutput==null?
                 null:
                 runOutput.getActualResultSummary();
@@ -97,7 +94,7 @@ public class FixtureRunner {
      */
     @Deprecated
     public ResultSummary run(Fixture fixture) throws IOException {
-        ConcordionRunOutput results = RunResultsCache.SINGLETON.getFromCache(fixture, null);
+        RunOutput results = RunResultsCache.SINGLETON.getFromCache(fixture, null);
 
         ResultSummary resultSummary = run(null, fixture);
 

--- a/src/main/java/org/concordion/internal/FixtureRunner.java
+++ b/src/main/java/org/concordion/internal/FixtureRunner.java
@@ -23,15 +23,11 @@ public class FixtureRunner {
     }
 
     public ResultSummary run(String example, Fixture fixture) throws IOException {
-    	
+
     	ConcordionRunOutput runOutput = runResultsCache.startRun(fixture, example);
         ResultSummary actualResultSummary = runOutput==null?
                 null:
                 runOutput.getActualResultSummary();
-
-        ResultSummary modifiedResultSummary = runOutput==null?
-                null:
-                runOutput.getModifiedResultSummary();
 
         String additionalInformation = null;
     	if (runOutput == null) {
@@ -47,21 +43,18 @@ public class FixtureRunner {
                                 actualResultSummary.getImplementationStatus());
                     } finally {
                         fixture.afterExample(example);
-                    } 
+                    }
                 } else {
                     actualResultSummary = concordion.process(fixture);
                     statusChecker = ImplementationStatusChecker.getImplementationStatusChecker(
                             fixture,
                             null);
                 }
-                // we want to make sure all the annotations are considered when storing the result summary
-                // converting for the cache doesn't need the example - it just does annotation based conversions
-                modifiedResultSummary = statusChecker.convertForCache(actualResultSummary);
 
                 runResultsCache.finishRun(fixture,
                         example,
                         actualResultSummary,
-                        modifiedResultSummary);
+                        statusChecker);
 
             } catch (RuntimeException e) {
                 // the run failed miserably. Tell the cache that the run failed
@@ -107,7 +100,7 @@ public class FixtureRunner {
         ConcordionRunOutput results = RunResultsCache.SINGLETON.getFromCache(fixture, null);
 
         ResultSummary resultSummary = run(null, fixture);
-        
+
         // only actually finish the specification if it has not already been run.
         if (results == null) {
             concordion.finish();

--- a/src/main/java/org/concordion/internal/RunOutput.java
+++ b/src/main/java/org/concordion/internal/RunOutput.java
@@ -1,0 +1,20 @@
+package org.concordion.internal;
+
+import org.concordion.api.ResultSummary;
+
+/**
+ * Returns the results of running a test. Applies to multiple levels, eg. example or specification level.
+ */
+public interface RunOutput {
+    /**
+     * The actual results of the test run.
+     * @return actual results
+     */
+    ResultSummary getActualResultSummary();
+
+    /**
+     * The results of the test run, modified to account for {@link org.concordion.api.ImplementationStatus}.
+     * @return modified results
+     */
+    ResultSummary getModifiedResultSummary();
+}

--- a/src/main/java/org/concordion/internal/SpecificationToSpecificationByExampleAdaptor.java
+++ b/src/main/java/org/concordion/internal/SpecificationToSpecificationByExampleAdaptor.java
@@ -13,7 +13,7 @@ public class SpecificationToSpecificationByExampleAdaptor implements Specificati
     public SpecificationToSpecificationByExampleAdaptor(Specification s) {
         specification = s;
     }
-    
+
     public void finish() {
     }
 
@@ -40,5 +40,10 @@ public class SpecificationToSpecificationByExampleAdaptor implements Specificati
     @Override
     public boolean hasExampleCommandNodes() {
         return false;
+    }
+
+    @Override
+    public String getSpecificationDescription() {
+        return testDescription;
     }
 }

--- a/src/main/java/org/concordion/internal/XMLSpecification.java
+++ b/src/main/java/org/concordion/internal/XMLSpecification.java
@@ -14,11 +14,12 @@ public class XMLSpecification implements SpecificationByExample {
     public static final String OUTER_EXAMPLE_SUFFIX = " " + OUTER_EXAMPLE_NAME;
 
     private String testDescription;
-
     private final CommandCall rootCommandNode;
+
     private final SpecificationCommand specificationCommand;
     private final List<CommandCall> examples;
     private final List<CommandCall> beforeExamples;
+    private final String specificationDescription;
 
     public XMLSpecification(CommandCall rootCommandNode) {
         this.rootCommandNode = rootCommandNode;
@@ -27,6 +28,7 @@ public class XMLSpecification implements SpecificationByExample {
         }
         specificationCommand = (SpecificationCommand) rootCommandNode.getCommand();
         specificationCommand.start(rootCommandNode);
+        specificationDescription = specificationCommand.getSpecificationDescription(rootCommandNode);
 
         examples = new ArrayList<CommandCall>();
         beforeExamples = new ArrayList<CommandCall>();
@@ -66,7 +68,7 @@ public class XMLSpecification implements SpecificationByExample {
                 }
             }
         }
-        
+
         if (node.getCommand().isExample()) {
             node.getCommand().executeAsExample(node, evaluator, resultRecorder);
         } else {
@@ -115,6 +117,11 @@ public class XMLSpecification implements SpecificationByExample {
         return examples.size() > 0;
     }
 
+    @Override
+    public String getSpecificationDescription() {
+        return specificationDescription;
+    }
+
     public List<String> getExampleNames() {
 
         List<String> commands = new ArrayList<String>();
@@ -157,7 +164,7 @@ public class XMLSpecification implements SpecificationByExample {
 
         return commands;
     }
-    
+
     public void finish() {
         specificationCommand.finish(rootCommandNode);
     }

--- a/src/main/java/org/concordion/internal/cache/CompositeRunOutput.java
+++ b/src/main/java/org/concordion/internal/cache/CompositeRunOutput.java
@@ -1,28 +1,29 @@
 package org.concordion.internal.cache;
 
 import org.concordion.api.ResultSummary;
+import org.concordion.internal.RunOutput;
 import org.concordion.internal.SummarizingResultRecorder;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class CompositeRunOutput extends ConcordionRunOutput {
-    private List<ConcordionRunOutput> results = new ArrayList<ConcordionRunOutput>();
+class CompositeRunOutput implements RunOutput {
+    private List<RunOutput> results = new ArrayList<RunOutput>();
     private String specificationDescription;
 
     public CompositeRunOutput(String specificationDescription) {
-        super(null);
+        super();
         this.specificationDescription = specificationDescription;
     }
 
-    public void add(ConcordionRunOutput exampleRunOutput) {
+    public void add(RunOutput exampleRunOutput) {
         results.add(exampleRunOutput);
     }
 
     @Override
     public ResultSummary getActualResultSummary() {
         SummarizingResultRecorder totalResultSummary = new SummarizingResultRecorder(specificationDescription);
-        for (ConcordionRunOutput result : results) {
+        for (RunOutput result : results) {
             totalResultSummary.record(result.getActualResultSummary());
         }
         return totalResultSummary;
@@ -31,7 +32,7 @@ public class CompositeRunOutput extends ConcordionRunOutput {
     @Override
     public ResultSummary getModifiedResultSummary() {
         SummarizingResultRecorder totalResultSummary = new SummarizingResultRecorder(specificationDescription);
-        for (ConcordionRunOutput result : results) {
+        for (RunOutput result : results) {
             totalResultSummary.record(result.getModifiedResultSummary());
         }
         return totalResultSummary;

--- a/src/main/java/org/concordion/internal/cache/CompositeRunOutput.java
+++ b/src/main/java/org/concordion/internal/cache/CompositeRunOutput.java
@@ -1,0 +1,39 @@
+package org.concordion.internal.cache;
+
+import org.concordion.api.ResultSummary;
+import org.concordion.internal.SummarizingResultRecorder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CompositeRunOutput extends ConcordionRunOutput {
+    private List<ConcordionRunOutput> results = new ArrayList<ConcordionRunOutput>();
+    private String specificationDescription;
+
+    public CompositeRunOutput(String specificationDescription) {
+        super(null);
+        this.specificationDescription = specificationDescription;
+    }
+
+    public void add(ConcordionRunOutput exampleRunOutput) {
+        results.add(exampleRunOutput);
+    }
+
+    @Override
+    public ResultSummary getActualResultSummary() {
+        SummarizingResultRecorder totalResultSummary = new SummarizingResultRecorder(specificationDescription);
+        for (ConcordionRunOutput result : results) {
+            totalResultSummary.record(result.getActualResultSummary());
+        }
+        return totalResultSummary;
+    }
+
+    @Override
+    public ResultSummary getModifiedResultSummary() {
+        SummarizingResultRecorder totalResultSummary = new SummarizingResultRecorder(specificationDescription);
+        for (ConcordionRunOutput result : results) {
+            totalResultSummary.record(result.getModifiedResultSummary());
+        }
+        return totalResultSummary;
+    }
+}

--- a/src/main/java/org/concordion/internal/cache/ConcordionRunOutput.java
+++ b/src/main/java/org/concordion/internal/cache/ConcordionRunOutput.java
@@ -1,23 +1,25 @@
 package org.concordion.internal.cache;
 
-import org.concordion.api.FixtureDeclarations;
 import org.concordion.api.Result;
 import org.concordion.api.ResultSummary;
 import org.concordion.internal.ImplementationStatusChecker;
+import org.concordion.internal.RunOutput;
 
 /**
  * Data to store in the cache
  */
-public class ConcordionRunOutput {
+class ConcordionRunOutput implements RunOutput {
     private static final CacheResultSummary IN_PROGRESS_RESULT_SUMMARY = new CacheResultSummary(Result.IGNORED,
             "No current results as the specification is currently being executed");
     private ResultSummary actualResultSummary;
     private ImplementationStatusChecker statusChecker;
 
-    public ConcordionRunOutput(FixtureDeclarations fixture) {
+    public ConcordionRunOutput() {
         this.actualResultSummary = IN_PROGRESS_RESULT_SUMMARY;
+        statusChecker = ImplementationStatusChecker.EXPECTED_TO_PASS;
     }
 
+    @Override
     public ResultSummary getActualResultSummary() {
         return actualResultSummary;
     }
@@ -26,6 +28,7 @@ public class ConcordionRunOutput {
         this.actualResultSummary = actualResultSummary;
     }
 
+    @Override
     public ResultSummary getModifiedResultSummary() {
         return statusChecker.convertForCache(getActualResultSummary());
     }

--- a/src/main/java/org/concordion/internal/cache/ConcordionRunOutput.java
+++ b/src/main/java/org/concordion/internal/cache/ConcordionRunOutput.java
@@ -3,6 +3,7 @@ package org.concordion.internal.cache;
 import org.concordion.api.FixtureDeclarations;
 import org.concordion.api.Result;
 import org.concordion.api.ResultSummary;
+import org.concordion.internal.ImplementationStatusChecker;
 
 /**
  * Data to store in the cache
@@ -11,16 +12,10 @@ public class ConcordionRunOutput {
     private static final CacheResultSummary IN_PROGRESS_RESULT_SUMMARY = new CacheResultSummary(Result.IGNORED,
             "No current results as the specification is currently being executed");
     private ResultSummary actualResultSummary;
-    private ResultSummary modifiedResultSummary;
+    private ImplementationStatusChecker statusChecker;
 
     public ConcordionRunOutput(FixtureDeclarations fixture) {
         this.actualResultSummary = IN_PROGRESS_RESULT_SUMMARY;
-        this.modifiedResultSummary = IN_PROGRESS_RESULT_SUMMARY;
-    }
-
-    public ConcordionRunOutput(ResultSummary actualResultSummary, ResultSummary modifiedResultSummary) {
-        this.actualResultSummary = actualResultSummary;
-        this.modifiedResultSummary = modifiedResultSummary;
     }
 
     public ResultSummary getActualResultSummary() {
@@ -32,10 +27,10 @@ public class ConcordionRunOutput {
     }
 
     public ResultSummary getModifiedResultSummary() {
-        return modifiedResultSummary;
+        return statusChecker.convertForCache(getActualResultSummary());
     }
 
-    public void setModifiedResultSummary(ResultSummary modifiedResultSummary) {
-        this.modifiedResultSummary = modifiedResultSummary;
+    public void setStatusChecker(ImplementationStatusChecker statusChecker) {
+        this.statusChecker = statusChecker;
     }
 }

--- a/src/main/java/org/concordion/internal/command/SpecificationCommand.java
+++ b/src/main/java/org/concordion/internal/command/SpecificationCommand.java
@@ -15,11 +15,12 @@ public class SpecificationCommand extends AbstractCommand {
     public void setUp(CommandCall commandCall, Evaluator evaluator, ResultRecorder resultRecorder) {
         throw new IllegalStateException("Unexpected call to " + getClass().getSimpleName() + "'s setUp() method. Only the execute() method should be called.");
     }
-    
+
+    // As of Concordion 2.0.0, this is only now called for JUnit 3 tests, since each example is executed individually for JUnit4 tests
     @Override
     public void execute(CommandCall commandCall, Evaluator evaluator, ResultRecorder resultRecorder) {
         if (specificationDescriber != null) {
-            resultRecorder.setSpecificationDescription(specificationDescriber.getDescription(commandCall.getResource()));
+            resultRecorder.setSpecificationDescription(getSpecificationDescription(commandCall));
         }
 
         try {
@@ -27,6 +28,10 @@ public class SpecificationCommand extends AbstractCommand {
         } catch (FailFastException e) {
             // Ignore - it'll be re-thrown later if necessary.
         }
+    }
+
+    public String getSpecificationDescription(CommandCall commandCall) {
+        return specificationDescriber.getDescription(commandCall.getResource());
     }
 
     public void start(CommandCall commandCall) {
@@ -44,7 +49,7 @@ public class SpecificationCommand extends AbstractCommand {
 
     private List<SpecificationProcessingListener> listeners = new ArrayList<SpecificationProcessingListener>();
     private SpecificationDescriber specificationDescriber;
-    
+
     public void addSpecificationListener(SpecificationProcessingListener listener) {
         listeners.add(listener);
     }

--- a/src/main/java/org/concordion/internal/runner/DefaultConcordionRunner.java
+++ b/src/main/java/org/concordion/internal/runner/DefaultConcordionRunner.java
@@ -7,7 +7,7 @@ import org.concordion.internal.FailFastException;
 import org.concordion.internal.FixtureSpecificationMapper;
 import org.concordion.internal.FixtureType;
 import org.concordion.internal.SummarizingResultRecorder;
-import org.concordion.internal.cache.ConcordionRunOutput;
+import org.concordion.internal.RunOutput;
 import org.concordion.internal.cache.RunResultsCache;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.notification.Failure;
@@ -49,7 +49,7 @@ public class DefaultConcordionRunner implements Runner {
 
         // check the cache - if the test was a concordion test, it will have stuck the results
         // in the cache. Use "null" for the example to get the accumulated values from all examples
-        ConcordionRunOutput concordionRunOutput = cache.getFromCache(fixtureClass, null);
+        RunOutput concordionRunOutput = cache.getFromCache(fixtureClass, null);
 
         // check the test actually put something in the cache
         if (concordionRunOutput == null) {

--- a/src/test/java/org/concordion/internal/runner/CachedResultsUnitTest.java
+++ b/src/test/java/org/concordion/internal/runner/CachedResultsUnitTest.java
@@ -7,8 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import org.concordion.internal.FixtureInstance;
-import org.concordion.internal.ImplementationStatusChecker;
-import org.concordion.internal.cache.ConcordionRunOutput;
+import org.concordion.internal.RunOutput;
 import org.concordion.internal.cache.RunResultsCache;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,14 +31,13 @@ public class CachedResultsUnitTest {
         assertNull(runResults.startRun(new FixtureInstance(this), null));
 
         // but if it's called again, we'll get some "in progress" results
-        ConcordionRunOutput concordionRunOutput = runResults.startRun(new FixtureInstance(this), null);
+        RunOutput concordionRunOutput = runResults.startRun(new FixtureInstance(this), null);
         assertNotNull(concordionRunOutput);
         assertThat(concordionRunOutput.getActualResultSummary().getExceptionCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getActualResultSummary().getSuccessCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getActualResultSummary().getFailureCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getActualResultSummary().getIgnoredCount(), is(equalTo(1L)));
 
-        concordionRunOutput.setStatusChecker(ImplementationStatusChecker.EXPECTED_TO_PASS);
         assertThat(concordionRunOutput.getModifiedResultSummary().getExceptionCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getModifiedResultSummary().getSuccessCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getModifiedResultSummary().getFailureCount(), is(equalTo(0L)));
@@ -54,19 +52,17 @@ public class CachedResultsUnitTest {
         assertNull(runResults.startRun(new FixtureInstance(this), EXAMPLE_1_NAME));
 
         // but if it's called again, we'll get some "in progress" results
-        ConcordionRunOutput concordionRunOutput = runResults.startRun(new FixtureInstance(this), EXAMPLE_1_NAME);
+        RunOutput concordionRunOutput = runResults.startRun(new FixtureInstance(this), EXAMPLE_1_NAME);
         assertNotNull(concordionRunOutput);
         assertThat(concordionRunOutput.getActualResultSummary().getExceptionCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getActualResultSummary().getSuccessCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getActualResultSummary().getFailureCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getActualResultSummary().getIgnoredCount(), is(equalTo(1L)));
 
-        concordionRunOutput.setStatusChecker(ImplementationStatusChecker.EXPECTED_TO_PASS);
         assertThat(concordionRunOutput.getModifiedResultSummary().getExceptionCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getModifiedResultSummary().getSuccessCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getModifiedResultSummary().getFailureCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getModifiedResultSummary().getIgnoredCount(), is(equalTo(1L)));
-
     }
 
 

--- a/src/test/java/org/concordion/internal/runner/CachedResultsUnitTest.java
+++ b/src/test/java/org/concordion/internal/runner/CachedResultsUnitTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import org.concordion.internal.FixtureInstance;
+import org.concordion.internal.ImplementationStatusChecker;
 import org.concordion.internal.cache.ConcordionRunOutput;
 import org.concordion.internal.cache.RunResultsCache;
 import org.junit.Before;
@@ -16,7 +17,7 @@ public class CachedResultsUnitTest {
 
     public static final String EXAMPLE_1_NAME = "eg1";
     public static final String EXAMPLE_2_NAME = "eg2";
-    
+
     private RunResultsCache runResults = RunResultsCache.SINGLETON;
 
     @Before
@@ -38,6 +39,7 @@ public class CachedResultsUnitTest {
         assertThat(concordionRunOutput.getActualResultSummary().getFailureCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getActualResultSummary().getIgnoredCount(), is(equalTo(1L)));
 
+        concordionRunOutput.setStatusChecker(ImplementationStatusChecker.EXPECTED_TO_PASS);
         assertThat(concordionRunOutput.getModifiedResultSummary().getExceptionCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getModifiedResultSummary().getSuccessCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getModifiedResultSummary().getFailureCount(), is(equalTo(0L)));
@@ -59,6 +61,7 @@ public class CachedResultsUnitTest {
         assertThat(concordionRunOutput.getActualResultSummary().getFailureCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getActualResultSummary().getIgnoredCount(), is(equalTo(1L)));
 
+        concordionRunOutput.setStatusChecker(ImplementationStatusChecker.EXPECTED_TO_PASS);
         assertThat(concordionRunOutput.getModifiedResultSummary().getExceptionCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getModifiedResultSummary().getSuccessCount(), is(equalTo(0L)));
         assertThat(concordionRunOutput.getModifiedResultSummary().getFailureCount(), is(equalTo(0L)));

--- a/src/test/java/spec/concordion/results/runTotals/RunTotalsFixture.java
+++ b/src/test/java/spec/concordion/results/runTotals/RunTotalsFixture.java
@@ -49,7 +49,7 @@ public class RunTotalsFixture {
 		}
 
 		File fileName = new File(parentFile, href);
-		System.out.println(fileName.getAbsolutePath());
+//		System.out.println(fileName.getAbsolutePath());
         boolean isOutputGenerated = fileName.exists();
 
 		Map<String, String> result = createMap(recorder, isOutputGenerated);


### PR DESCRIPTION
Rework implementation of result recording to fix issue with ParallelRunExtension, and simplify the handling of results. See individual commits for details.

There are some whitespace changes. You should be able to add `?w=1` to the URL to ignore whitespace - however this wasn't working for me. You can see the diff without whitespace changes at https://github.com/concordion/concordion/compare/master...nigelcharman:restructure-result-recording?w=1.

