### PR TITLE
Add outer example listener.

### DIFF
--- a/src/main/java/org/concordion/api/extension/ConcordionExtender.java
+++ b/src/main/java/org/concordion/api/extension/ConcordionExtender.java
@@ -10,15 +10,15 @@ import org.concordion.internal.listener.BreadcrumbRenderer;
  */
 public interface ConcordionExtender {
     /**
-     * Adds a command to Concordion.  
-     * @param namespaceURI the URI to be used for the namespace of the command.  Must not be <code>concordion.org</code>. 
+     * Adds a command to Concordion.
+     * @param namespaceURI the URI to be used for the namespace of the command.  Must not be <code>concordion.org</code>.
      * @param commandName the name to be used for the command.  The fully qualified name composed of the <code>namespaceURI</code> and
-     * <code>commandName</code> must be used to reference the command in the Concordion specification. 
+     * <code>commandName</code> must be used to reference the command in the Concordion specification.
      * @param command the command to be executed
      * @return this
      */
     ConcordionExtender withCommand(String namespaceURI, String commandName, Command command);
-    
+
     /**
      * Adds a listener to <code>concordion:assertEquals</code> commands.
      * @param listener the listener
@@ -60,7 +60,7 @@ public interface ConcordionExtender {
      * @return this
      */
     ConcordionExtender withRunListener(RunListener listener);
-    
+
     /**
      * Adds a listener to <code>concordion:verifyRows</code> commands.
      * @param listener the listener
@@ -75,9 +75,9 @@ public interface ConcordionExtender {
      * @return this
      */
     ConcordionExtender withThrowableListener(ThrowableCaughtListener throwableListener);
-    
+
     /**
-     * Adds a listener that is invoked when Concordion parses the specification document, providing 
+     * Adds a listener that is invoked when Concordion parses the specification document, providing
      * access to the parsed document.
      * @param listener the listener
      * @return this
@@ -86,7 +86,7 @@ public interface ConcordionExtender {
 
     /**
      * Adds a listener that is invoked before and after Concordion has processed the specification,
-     * providing access to the specification resource and root element. 
+     * providing access to the specification resource and root element.
      * @param listener the listener
      * @return this
      */
@@ -94,20 +94,29 @@ public interface ConcordionExtender {
 
     /**
      * Adds a listener that is invoked before and after Concordion has processed the example,
-     * providing access to the example node. 
+     * providing access to the example node.
      * @param listener the listener
      * @return this
      */
     ConcordionExtender withExampleListener(ExampleListener listener);
-    
+
+    /**
+     * Adds a listener that is invoked before and after Concordion has processed the "outer" example (which includes
+     * all commands in a specification not inside an example command).
+     * @param listener the listener
+     * @return this
+     * @since 2.0.2
+     */
+    ConcordionExtender withOuterExampleListener(OuterExampleListener listener);
+
     /**
      * Adds a listener that is invoked when a Concordion instance is built, providing access to the {@link Target}
-     * to which resources can be written.  
+     * to which resources can be written.
      * @param listener the listener
      * @return this
      */
     ConcordionExtender withBuildListener(ConcordionBuildListener listener);
-    
+
     /**
      * Copies a resource to the Concordion output.
      * @param sourcePath Storage Path
@@ -115,14 +124,14 @@ public interface ConcordionExtender {
      * @return this
      */
     ConcordionExtender withResource(String sourcePath, Resource targetResource);
-    
+
     /**
      * Embeds the given CSS in the Concordion output.
      * @param css CSS
      * @return this
      */
     ConcordionExtender withEmbeddedCSS(String css);
-    
+
     /**
      * Embeds the given CSS in the Concordion output.
      * @param css CSS
@@ -130,24 +139,24 @@ public interface ConcordionExtender {
      * @return this
      */
     ConcordionExtender withEmbeddedCSS(String css, boolean append);
-    
+
     /**
-     * Copies the given CSS file to the Concordion output folder, and adds a link to the CSS in the &lt;head&gt; section of the Concordion HTML.  
+     * Copies the given CSS file to the Concordion output folder, and adds a link to the CSS in the &lt;head&gt; section of the Concordion HTML.
      * @param cssPath CSS Path
      * @param targetResource Target Resource
      * @return this
      */
     ConcordionExtender withLinkedCSS(String cssPath, Resource targetResource);
-    
+
     /**
      * Embeds the given JavaScript in the Concordion output.
      * @param javaScript javaScript
      * @return this
      */
     ConcordionExtender withEmbeddedJavaScript(String javaScript);
-    
+
     /**
-     * Copies the given JavaScript file to the Concordion output folder, and adds a link to the JavaScript in the &lt;head&gt; section of the Concordion HTML.  
+     * Copies the given JavaScript file to the Concordion output folder, and adds a link to the JavaScript in the &lt;head&gt; section of the Concordion HTML.
      * @param jsPath path to javascript
      * @param targetResource target resource
      * @return this
@@ -156,14 +165,14 @@ public interface ConcordionExtender {
 
     /**
      * Overrides the source that the Concordion specifications are read from.
-     * @param source the new source 
+     * @param source the new source
      * @return this
      */
     ConcordionExtender withSource(Source source);
 
     /**
      * Overrides the target that the Concordion specifications are written to.
-     * @param target the new target 
+     * @param target the new target
      * @return this
      */
     ConcordionExtender withTarget(Target target);
@@ -181,7 +190,7 @@ public interface ConcordionExtender {
      * @return this
      */
     ConcordionExtender withRunStrategy(RunStrategy runStrategy);
-    
+
     /**
      * Overrides the listener for rendering bread crumbs.
      * @param breadcrumbRenderer the new bread crumb renderer
@@ -190,7 +199,7 @@ public interface ConcordionExtender {
     ConcordionExtender withBreadcrumbRenderer(BreadcrumbRenderer breadcrumbRenderer);
 
     /**
-     * Adds a new specification type to the types that can be handled (by default HTML and Markdown are supported). 
+     * Adds a new specification type to the types that can be handled (by default HTML and Markdown are supported).
      * @param typeSuffix the suffix of the file type to map this to
      * @param specificationConverter converts the specification to HTML format
      * @return this

--- a/src/main/java/org/concordion/api/listener/OuterExampleEvent.java
+++ b/src/main/java/org/concordion/api/listener/OuterExampleEvent.java
@@ -1,0 +1,32 @@
+package org.concordion.api.listener;
+
+import org.concordion.api.Element;
+import org.concordion.api.ResultSummary;
+
+/**
+ * @since 2.0.2
+ */
+public class OuterExampleEvent {
+
+    private final Element element;
+    private final ResultSummary resultSummary;
+    private final String exampleName;
+
+    public OuterExampleEvent(String exampleName, Element element, ResultSummary resultSummary) {
+        this.exampleName = exampleName;
+        this.resultSummary = resultSummary;
+        this.element = element;
+    }
+
+    public Element getElement() {
+        return element;
+    }
+
+    public ResultSummary getResultSummary() {
+        return resultSummary;
+    }
+
+    public String getExampleName() {
+        return exampleName;
+    }
+}

--- a/src/main/java/org/concordion/api/listener/OuterExampleListener.java
+++ b/src/main/java/org/concordion/api/listener/OuterExampleListener.java
@@ -1,0 +1,9 @@
+package org.concordion.api.listener;
+
+/**
+ * @since 2.0.2
+ */
+public interface OuterExampleListener {
+    void beforeOuterExample(OuterExampleEvent event);
+    void afterOuterExample(OuterExampleEvent event);
+}

--- a/src/main/java/org/concordion/internal/ConcordionBuilder.java
+++ b/src/main/java/org/concordion/internal/ConcordionBuilder.java
@@ -33,7 +33,7 @@ public class ConcordionBuilder implements ConcordionExtender {
     private static final String PROPERTY_OUTPUT_DIR = "concordion.output.dir";
     private static final String PROPERTY_EXTENSIONS = "concordion.extensions";
     private static final String EMBEDDED_STYLESHEET_RESOURCE = "/org/concordion/internal/resource/embedded.css";
-    
+
     private static File baseOutputDir;
     private SpecificationLocator specificationLocator = new ClassNameAndTypeBasedSpecificationLocator();
     private Map<SourceType, Source> sources = new HashMap<SourceType, Source>();
@@ -72,9 +72,9 @@ public class ConcordionBuilder implements ConcordionExtender {
     {
         ExtensionChecker.checkForOutdatedExtensions();
         commandRegistry.register("", "specification", specificationCommand);
-        
+
         withSource(new ClassPathSource());
-        
+
         AssertResultRenderer assertRenderer = new AssertResultRenderer();
         withAssertEqualsListener(assertRenderer);
         withAssertTrueListener(assertRenderer);
@@ -111,7 +111,7 @@ public class ConcordionBuilder implements ConcordionExtender {
         this.pageFooterRenderer = pageFooterRenderer;
         return this;
     }
-    
+
     public ConcordionBuilder withBreadcrumbRenderer(BreadcrumbRenderer breadcrumbRenderer) {
     	this.breadcrumbRenderer = breadcrumbRenderer;
     	return this;
@@ -131,7 +131,7 @@ public class ConcordionBuilder implements ConcordionExtender {
         this.evaluatorFactory = evaluatorFactory;
         return this;
     }
-    
+
     public ConcordionBuilder withThrowableListener(ThrowableCaughtListener throwableListener) {
         throwableListenerPublisher.addThrowableListener(throwableListener);
         return this;
@@ -141,27 +141,27 @@ public class ConcordionBuilder implements ConcordionExtender {
         assertEqualsCommand.addAssertEqualsListener(listener);
         return this;
     }
-    
+
     public ConcordionBuilder withAssertTrueListener(AssertTrueListener listener) {
         assertTrueCommand.addAssertListener(listener);
         return this;
     }
-    
+
     public ConcordionBuilder withAssertFalseListener(AssertFalseListener listener) {
         assertFalseCommand.addAssertListener(listener);
         return this;
     }
-    
+
     public ConcordionBuilder withVerifyRowsListener(VerifyRowsListener listener) {
         verifyRowsCommand.addVerifyRowsListener(listener);
         return this;
     }
-    
+
     public ConcordionBuilder withRunListener(RunListener listener) {
         runCommand.addRunListener(listener);
         return this;
     }
-    
+
     public ConcordionExtender withRunStrategy(RunStrategy runStrategy) {
         runCommand.setRunStrategy(runStrategy);
         return this;
@@ -191,7 +191,7 @@ public class ConcordionBuilder implements ConcordionExtender {
         listeners.add(listener);
         return this;
     }
-    
+
     private ConcordionBuilder withApprovedCommand(String namespaceURI, String commandName, Command command) {
         ThrowableCatchingDecorator throwableCatchingDecorator = new ThrowableCatchingDecorator(new LocalTextDecorator(command), failFastExceptions);
         throwableCatchingDecorator.addThrowableListener(throwableListenerPublisher);
@@ -209,7 +209,7 @@ public class ConcordionBuilder implements ConcordionExtender {
                         + "must not contain 'concordion.org'. Use your own domain name instead.");
         return withApprovedCommand(namespaceURI, commandName, command);
     }
-    
+
     public ConcordionBuilder withResource(String sourcePath, Resource targetResource) {
         resourceToCopyMap.put(sourcePath, targetResource);
         return this;
@@ -220,13 +220,13 @@ public class ConcordionBuilder implements ConcordionExtender {
         withDocumentParsingListener(embedder);
         return this;
     }
-    
+
     public ConcordionBuilder withEmbeddedCSS(String css, boolean append) {
         StylesheetEmbedder embedder = new StylesheetEmbedder(css, append);
         withDocumentParsingListener(embedder);
         return this;
     }
-    
+
     public ConcordionBuilder withLinkedCSS(String cssPath, Resource targetResource) {
         withResource(cssPath, targetResource);
         StylesheetLinker cssLinker = new StylesheetLinker(targetResource);
@@ -248,11 +248,11 @@ public class ConcordionBuilder implements ConcordionExtender {
         withSpecificationProcessingListener(javaScriptLinker);
         return this;
     }
-    
+
     public Concordion build() throws UnableToBuildConcordionException {
         Check.isFalse(builtAlready, "ConcordionBuilder currently does not support calling build() twice");
         builtAlready = true;
-        
+
         withApprovedCommand(NAMESPACE_CONCORDION_2007, "run", runCommand);
         withApprovedCommand(NAMESPACE_CONCORDION_2007, "execute", executeCommand);
         withApprovedCommand(NAMESPACE_CONCORDION_2007, "set", setCommand);
@@ -263,18 +263,18 @@ public class ConcordionBuilder implements ConcordionExtender {
 
         withApprovedCommand(NAMESPACE_CONCORDION_2007, "assert-true", assertTrueCommand);
         withApprovedCommand(NAMESPACE_CONCORDION_2007, "assertTrue", assertTrueCommand);
-        
+
         withApprovedCommand(NAMESPACE_CONCORDION_2007, "assert-false", assertFalseCommand);
         withApprovedCommand(NAMESPACE_CONCORDION_2007, "assertFalse", assertFalseCommand);
-        
+
         withApprovedCommand(NAMESPACE_CONCORDION_2007, "verify-rows", verifyRowsCommand);
         withApprovedCommand(NAMESPACE_CONCORDION_2007, "verifyRows", verifyRowsCommand);
-        
+
         withApprovedCommand(NAMESPACE_CONCORDION_2007, "echo", echoCommand);
-        
+
         Source resourceSource = sources.get(SourceType.RESOURCE);
         Source specificationSource = sources.get(SourceType.SPECIFICATION);
-        
+
         withThrowableListener(new ThrowableRenderer(resourceSource));
         withRunListener(new RunResultRenderer(resourceSource));
 
@@ -282,7 +282,7 @@ public class ConcordionBuilder implements ConcordionExtender {
             target = new FileTarget(getBaseOutputDir());
         }
         XMLParser xmlParser = new XMLParser();
-        
+
         if (breadcrumbRenderer == null) {
         	breadcrumbRenderer = new BreadcrumbRenderer(specificationSource, xmlParser, specificationTypes);
         }
@@ -387,7 +387,7 @@ public class ConcordionBuilder implements ConcordionExtender {
                 baseOutputDir = new File(outputPath);
             } else {
                 baseOutputDir = new File(System.getProperty("java.io.tmpdir"), "concordion");
-            } 
+            }
         }
         return baseOutputDir;
     }
@@ -399,9 +399,9 @@ public class ConcordionBuilder implements ConcordionExtender {
 
     public ConcordionBuilder withFixture(Fixture fixture) {
         this.fixture = fixture;
-        
+
         withResources(fixture);
-        
+
         if (fixture.declaresFailFast()) {
             withFailFast(fixture.getDeclaredFailFastExceptions());
         }
@@ -411,20 +411,25 @@ public class ConcordionBuilder implements ConcordionExtender {
 
         return this;
     }
-    
+
     public ConcordionExtender withExampleListener(ExampleListener listener) {
 		exampleCommand.addExampleListener(listener);
 		return this;
 	}
-	
+
+    public ConcordionExtender withOuterExampleListener(OuterExampleListener listener) {
+        specificationCommand.addOuterExampleListener(listener);
+        return this;
+    }
+
     public ConcordionBuilder withResources(Fixture fixture) {
         boolean includeDefaultStyling = true;
-        
+
         Source resourceSource = sources.get(SourceType.RESOURCE);
         if (fixture.declaresResources()) {
         	ResourceFinder resources = new ResourceFinder(fixture);
         	List<ResourceToCopy> sourceFiles = resources.getResourcesToCopy();
-        	
+
         	for (ResourceToCopy sourceFile : sourceFiles) {
     			if (sourceFile.isStyleSheet()) {
     				if (sourceFile.insertType == InsertType.EMBEDDED) {
@@ -442,21 +447,21 @@ public class ConcordionBuilder implements ConcordionExtender {
     				withResource(sourceFile.getResourceName(), new Resource(sourceFile.getResourceName()));
     			}
     		}
-        			
+
         	includeDefaultStyling = resources.includeDefaultStyling();
-        	
+
         	withDocumentParsingListener(new ResourceReferenceRemover(sourceFiles));
-        } 
-        
+        }
+
         if (includeDefaultStyling) {
         	addDefaultStyling(resourceSource);
         }
-        
+
         return this;
     }
-    
+
 	private void addDefaultStyling(Source resourceSource) {
-    	String stylesheetContent = resourceSource.readResourceAsString(EMBEDDED_STYLESHEET_RESOURCE);    
+    	String stylesheetContent = resourceSource.readResourceAsString(EMBEDDED_STYLESHEET_RESOURCE);
     	withEmbeddedCSS(stylesheetContent);
     }
 


### PR DESCRIPTION
In order for the parallel run extension to wait for each example to finish requires a listener for the "outer" example (which includes all commands in a specification not inside an example command) in addition to the existing example listener (which is only triggered for example commands).

Needed for concordion/concordion-parallel-run-extension#3.