### PR TITLE
ImplementationStatus.html report is not displaying in chrome and firefox

### DIFF
--- a/src/test/resources/spec/concordion/annotation/ImplementationStatus.html
+++ b/src/test/resources/spec/concordion/annotation/ImplementationStatus.html
@@ -1,7 +1,5 @@
 <html xmlns:concordion="http://www.concordion.org/2007/concordion">
 <link href="../../../concordion.css" rel="stylesheet" type="text/css" />
-<link href="demo.css" rel="stylesheet" type="rubbish" />
-<script src="demo.js" type="rubbish"></script>
 <body>
 
   <h1>Implementation Status</h1>


### PR DESCRIPTION
concordion/concordion/build/reports/spec/concordion/annotation/ImplementationStatus.html was not displayed in chrome and firefox browsers due to missing demo.js and demo.css.

Should they be referenced from build/resource directory or just not be present for this spec?