### PR TITLE
Allow Markdown execute command to not require an attribute

### DIFF
--- a/src/main/java/org/concordion/internal/parser/support/ConciseExpressionParser.java
+++ b/src/main/java/org/concordion/internal/parser/support/ConciseExpressionParser.java
@@ -64,10 +64,14 @@ public class ConciseExpressionParser {
     private ConcordionStatement parseStatement(String statement, boolean includeConcordionPrefix) throws ConcordionSyntaxException {
         String[] components = statement.split("=", 2);
         String commandName = components[0];
-        if (components.length != 2) {
+        String valueAndAttributes;
+        if (components.length == 2) {
+            valueAndAttributes = components[1];
+        } else if (components.length == 1 && commandName.equals("example")) {
+            valueAndAttributes = "";
+        } else {
             throw new ConcordionSyntaxException(SimpleFormatter.format("Invalid statement '%s'. Expected an = sign and a right hand side to the statement.", statement));
         }
-        String valueAndAttributes = components[1];
 
         if (valueAndAttributes.contains("\"")) {
             throw new ConcordionSyntaxException(String.format("Invalid statement '%s'. Expected the right hand side to not contain double quotes.", statement));

--- a/src/test/resources/spec/concordion/specificationType/markdown/MarkdownExecuteCommand.md
+++ b/src/test/resources/spec/concordion/specificationType/markdown/MarkdownExecuteCommand.md
@@ -249,7 +249,7 @@ Without the concise syntax this would need to be written as:
     <tr>
       <td>
 <pre>      
-|[_add_](- "#z=add(#x, #y)") [Example Name](- "c:example=") | [Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
+|[_add_](- "#z=add(#x, #y)") [Example Name](- "c:example") | [Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
 | --------------------------                           | ----------------: | ---------------: | ---------------: |
 | Positive numbers                                     |                  1|                 0|                 1|
 | Negative numbers                                     |                  1|                -3|                -2|


### PR DESCRIPTION
For cases where the user wants the example name to be empty (eg. table headers).
This could be achieved using c:example=, but the '=' sign is confusing.
This can now be achieved using c:example.