### PR TITLE
Removed concise table format.

### DIFF
--- a/src/main/java/org/concordion/internal/parser/markdown/ConcordionHtmlSerializer.java
+++ b/src/main/java/org/concordion/internal/parser/markdown/ConcordionHtmlSerializer.java
@@ -100,8 +100,6 @@ public class ConcordionHtmlSerializer extends ToHtmlSerializer {
 // concordion:execute on a table and concordion:verifyRows
 // The concordion:execute command is in the first (and only) cell of the first header row.
 // The header row containing the command has to be removed, and the command needs to be printed on the table row.
-// If the first column contains only the execute command, we assume that each row is to be executed as an example
-// (with the first column of each table row containing the example name) and we add the example command.
 
     @Override
     public void visit(TableNode tableNode) {
@@ -112,12 +110,8 @@ public class ConcordionHtmlSerializer extends ToHtmlSerializer {
                 if (linkNode.getTitle() == null) {
                     throw new IllegalStateException(SimpleFormatter.format("No title found for link node '%s'", linkNode.getText()));
                 }
-                int numberOfLinkNodesInFirstColumn = numberOfLinkNodeChildren(cell);
                 pendingCommand = statementParser.parse(linkNode.getTitle(), linkNode.getText());
                 cell.getChildren().remove(0);
-                if (numberOfLinkNodesInFirstColumn == 1 && statementParser.isExecuteCommand(pendingCommand)) {
-                    addExampleCommand(cell, linkNode);
-                }
             }
         }
 
@@ -132,10 +126,6 @@ public class ConcordionHtmlSerializer extends ToHtmlSerializer {
         printer.print('>').indent(+2);
         visitChildren(node);
         printer.indent(-2).println().print('<').print('/').print(tag).print('>');
-    }
-
-    private void addExampleCommand(Node cell, LinkNode linkNode) {
-        cell.getChildren().add(new ExpLinkNode("c:example=", URL_FOR_CONCORDION, new TextNode(linkNode.getText())));
     }
 
     //-----------------------------------------------------------------------------------------------------------------------

--- a/src/main/java/org/concordion/internal/parser/support/ConciseExpressionParser.java
+++ b/src/main/java/org/concordion/internal/parser/support/ConciseExpressionParser.java
@@ -35,7 +35,9 @@ public class ConciseExpressionParser {
 
     public ConcordionStatement parse(String expression, String text) throws ConcordionSyntaxException {
         ConcordionStatement statement;
-        if (expression.startsWith("#") && !(expression.contains("="))) {
+        if (expression.equals("@")) {
+            statement = new ConcordionStatement(targetPrefix + "example", "");
+        } else if (expression.startsWith("#") && !(expression.contains("="))) {
             statement = new ConcordionStatement(targetPrefix + "set", expression);
         } else if (expression.startsWith("?=")) {
             statement = new ConcordionStatement(targetPrefix + "assert-equals", expression.substring(2));

--- a/src/test/resources/spec/concordion/specificationType/markdown/Markdown.md
+++ b/src/test/resources/spec/concordion/specificationType/markdown/Markdown.md
@@ -71,21 +71,24 @@ The Github Flavored Markdown [tables](https://help.github.com/articles/github-fl
 The command to be run on the table is specified in the first table header column, followed by the command for that column (if any), with the commands for each column of the table specified in the table header.
 
 ##### Execute on a table
-The execute command is specified in the first table header column, followed by the command for that column (if any), with the commands for each column of the table specified in the relevant table header column.
+The execute command is specified in the first table header column, followed by the command for that column (if any), 
+with the commands for each column of the table specified in the relevant table header column.
 
-    |[_add_](- "#z=add(#x, #y)")[Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
-    | ------------------------------------------: | ---------------: | ---------------: |
-    |                                            1|                 0|                 1|
-    |                                            1|                -3|                -2|
+The link text for the execute command is not used, but must contain at least 1 space, eg. `[ ]` to be a valid markdown link.
+
+    |[ ](- "#z=add(#x, #y)")[Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
+    | --------------------------------------: | ---------------: | ---------------: |
+    |                                        1|                 0|                 1|
+    |                                        1|                -3|                -2|
 
 Reference-style links can be used for one or more of the links to improve readability of the Markdown source: 
 
-    |[_add_][][Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
+    |[add][][Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
     | ------------------------: | ---------------: | ---------------: |
     |                          1|                 0|                 1|
     |                          1|                -3|                -2|
 
-    [_add_]: - "#z=add(#x, #y)"
+    [add]: - "#z=add(#x, #y)"
 
 ###### Run each row as an example
 _Since:_ Concordion 2.1.0
@@ -95,21 +98,21 @@ To do this, use the c:example tag in one of the table header columns and specify
 
 For example:
 
-    |[_add_](- "#z=add(#x, #y)") [Example Name](- "c:example=") | [Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
-    | --------------------------                                | ----------------: | ---------------: | ---------------: |
-    | Positive numbers                                          |                  1|                 0|                 1|
-    | Negative numbers                                          |                  1|                -3|                -2|
+    |[ ](- "#z=add(#x, #y)") [Example Name](- "c:example") | [Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
+    | --------------------------                           | ----------------: | ---------------: | ---------------: |
+    | Positive numbers                                     |                  1|                 0|                 1|
+    | Negative numbers                                     |                  1|                -3|                -2|
 
 __Concise syntax__
 
-To shorten the syntax when the first column of the table contains the example name, you can combine the execute command and the example command into one. 
+To shorten the syntax a bit, you can use `@` rather than `c:example` 
 
 For example:
 
-    |[Example Name](- "#z=add(#x, #y)") | [Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
-    | --------------------------         | ----------------: | ---------------: | ---------------: |
-    | Positive numbers                   |                  1|                 0|                 1|
-    | Negative numbers                   |                  1|                -3|                -2|
+    |[ ](- "#z=add(#x, #y)") [Example Name](- "@") | [Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
+    | --------------------------                   | ----------------: | ---------------: | ---------------: |
+    | Positive numbers                             |                  1|                 0|                 1|
+    | Negative numbers                             |                  1|                -3|                -2|
 
 ##### Verify Rows
 The verifyRows command is specified in the first table header column, followed by the command for that column (if any), with the commands for each column of the table specified in the relevant table header column.

--- a/src/test/resources/spec/concordion/specificationType/markdown/MarkdownExecuteCommand.md
+++ b/src/test/resources/spec/concordion/specificationType/markdown/MarkdownExecuteCommand.md
@@ -55,7 +55,8 @@ If the special variable `#TEXT` is used as a parameter within the _expression_, 
 
 <a id="execute-on-a-table"/>
 ### Execute on a table
-To run the [execute command on a table](http://concordion.org/Tutorial.html#executeTable), the execute command is specified in the first table header column, followed by the command for that column (if any), with the commands for each column of the table specified in the table header.
+To run the [execute command on a table](http://concordion.org/Tutorial.html#executeTable), the execute command is specified in the first table header column, 
+followed by the command for that column (if any), with the commands for each column of the table specified in the table header.
 
 <div class="example">
   <h3>Example</h3>
@@ -67,10 +68,10 @@ To run the [execute command on a table](http://concordion.org/Tutorial.html#exec
     <tr>
       <td>
 <pre>      
-|[_add_](- "#z=add(#x, #y)")[Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
-| ------------------------------------------: | ---------------: | ---------------: |
-|                                            1|                 0|                 1|
-|                                            1|                -3|                -2|
+|[ ](- "#z=add(#x, #y)")[Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
+| --------------------------------------: | ---------------: | ---------------: |
+|                                        1|                 0|                 1|
+|                                        1|                -3|                -2|
 </pre>
       </td>
       <td>
@@ -185,9 +186,8 @@ or even:
   </table>
 </div>
 
-#### Concise Table Syntax
-To run each row of the table as an example, include only the execute command in the first column header, and
-specify the example name as the first column in each row. The markdown parser will automatically add an example command. 
+#### Run each row as an example
+To run each row of the table as an example, add a "c:example" command to a column header. The text in that column will be used for the example name.  
 
 For example:
 
@@ -201,17 +201,17 @@ For example:
     <tr>
       <td>
 <pre>      
-|[Example Name](- "#z=add(#x, #y)") | [Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
-| --------------------------         | ----------------: | ---------------: | ---------------: |
-| Positive numbers                   |                  1|                 0|                 1|
-| Negative numbers                   |                  1|                -3|                -2|
+|[ ](- "#z=add(#x, #y)")[Example Name](- "c:example") | [Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
+| --------------------------                          | ----------------: | ---------------: | ---------------: |
+| Positive numbers                                    |                  1|                 0|                 1|
+| Negative numbers                                    |                  1|                -3|                -2|
 </pre>
       </td>
       <td>
 <![CDATA[<table concordion:execute="#z=add(#x, #y)">
     <thead>
         <tr>
-            <th concordion:example=""> Example Name</th>
+            <th concordion:example="">Example Name </th>
             <th align="right" concordion:set="#x">Number 1</th>
             <th align="right" concordion:set="#y">Number 2</th>
             <th align="right" concordion:assert-equals="#z">Result</th>
@@ -237,7 +237,7 @@ For example:
   </table>
 </div>
 
-Without the concise syntax this would need to be written as:
+As a shorthand syntax, "c:example" can be written as "@":
 
 <div class="example">
   <h3>Example</h3>
@@ -249,10 +249,10 @@ Without the concise syntax this would need to be written as:
     <tr>
       <td>
 <pre>      
-|[_add_](- "#z=add(#x, #y)") [Example Name](- "c:example") | [Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
-| --------------------------                           | ----------------: | ---------------: | ---------------: |
-| Positive numbers                                     |                  1|                 0|                 1|
-| Negative numbers                                     |                  1|                -3|                -2|
+|[ ](- "#z=add(#x, #y)") [Example Name](- "@") | [Number 1](- "#x")|[Number 2](- "#y")|[Result](- "?=#z")|
+| --------------------------                   | ----------------: | ---------------: | ---------------: |
+| Positive numbers                             |                  1|                 0|                 1|
+| Negative numbers                             |                  1|                -3|                -2|
 </pre>
       </td>
       <td>

--- a/src/test/resources/spec/concordion/specificationType/markdown/MarkdownGrammar.markdown
+++ b/src/test/resources/spec/concordion/specificationType/markdown/MarkdownGrammar.markdown
@@ -347,7 +347,7 @@ HTML entities in the text value are automatically escaped.
 | -------------- | ------------- | ------------- |
 | bar            |       a &lt; b   |            &lt;x&gt;|
 </pre></td>
-      <td>&lt;table concordion:execute="foo()"&gt; &lt;thead&gt; &lt;tr&gt; &lt;th concordion:example=""&gt;foo&lt;/th&gt; &lt;th concordion:set="#d"&gt;a &amp;lt; b&lt;/th&gt; &lt;th concordion:assert-equals="#d"&gt;&amp;lt;x&amp;gt;&lt;/th&gt; &lt;/tr&gt; &lt;/thead&gt; &lt;tbody&gt; &lt;tr&gt; &lt;td&gt;bar &lt;/td&gt; &lt;td&gt;a &amp;lt; b &lt;/td&gt; &lt;td&gt;&amp;lt;x&amp;gt;&lt;/td&gt; &lt;/tr&gt; &lt;/tbody&gt; &lt;/table&gt;</td>
+      <td>&lt;table concordion:execute="foo()"&gt; &lt;thead&gt; &lt;tr&gt; &lt;th&gt;&lt;/th&gt; &lt;th concordion:set="#d"&gt;a &amp;lt; b&lt;/th&gt; &lt;th concordion:assert-equals="#d"&gt;&amp;lt;x&amp;gt;&lt;/th&gt; &lt;/tr&gt; &lt;/thead&gt; &lt;tbody&gt; &lt;tr&gt; &lt;td&gt;bar &lt;/td&gt; &lt;td&gt;a &amp;lt; b &lt;/td&gt; &lt;td&gt;&amp;lt;x&amp;gt;&lt;/td&gt; &lt;/tr&gt; &lt;/tbody&gt; &lt;/table&gt;</td>
     </tr>
   </table>
 </div>


### PR DESCRIPTION
The concise format was breaking some existing specs for users.
The example command now needs to be explicitly stated in the column header, eg. `[ ](- "#z=add(#x, #y)")[Example Name](- "c:example")`
As an alternative, you can use the `@` symbol instead of `c:example`, eg. `[ ](- "#z=add(#x, #y)")[Example Name](- "@")`