### PR TITLE
Makes Concordion extendable by other frameworks

### DIFF
--- a/src/main/java/org/concordion/integration/junit3/ConcordionTestCase.java
+++ b/src/main/java/org/concordion/integration/junit3/ConcordionTestCase.java
@@ -3,6 +3,7 @@ package org.concordion.integration.junit3;
 import junit.framework.TestCase;
 
 import org.concordion.api.Fixture;
+import org.concordion.internal.ClassNameAndTypeBasedSpecificationLocator;
 import org.concordion.internal.FixtureInstance;
 import org.concordion.internal.FixtureRunner;
 
@@ -19,7 +20,7 @@ public abstract class ConcordionTestCase extends TestCase {
         Fixture fixture  = new FixtureInstance(this);
         fixture.beforeSpecification();
         fixture.setupForRun(this);
-        new FixtureRunner(fixture).run(fixture);
+        new FixtureRunner(fixture, new ClassNameAndTypeBasedSpecificationLocator()).run(fixture);
         fixture.afterSpecification();
     }
 }

--- a/src/main/java/org/concordion/integration/junit4/ConcordionRunner.java
+++ b/src/main/java/org/concordion/integration/junit4/ConcordionRunner.java
@@ -10,8 +10,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.concordion.Concordion;
 import org.concordion.api.Fixture;
 import org.concordion.api.ResultSummary;
+import org.concordion.api.SpecificationLocator;
 import org.concordion.internal.*;
-import org.concordion.internal.RunOutput;
 import org.concordion.internal.cache.RunResultsCache;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
@@ -59,7 +59,7 @@ public class ConcordionRunner extends BlockJUnit4ClassRunner {
         }
 
         try {
-            fixtureRunner = new FixtureRunner(setupFixture);
+            fixtureRunner = new FixtureRunner(setupFixture, getSpecificationLocator());
         } catch (UnableToBuildConcordionException e) {
             throw new InitializationError(e);
         }
@@ -81,7 +81,11 @@ public class ConcordionRunner extends BlockJUnit4ClassRunner {
         }
     }
 
-    private void verifyUniqueExampleMethods(List<String> exampleNames) throws InitializationError {
+    protected SpecificationLocator getSpecificationLocator() {
+		return new ClassNameAndTypeBasedSpecificationLocator();
+	}
+
+	private void verifyUniqueExampleMethods(List<String> exampleNames) throws InitializationError {
         // use a hash set to store examples - gives us quick lookup and add.
         Set<String> setOfExamples = new HashSet<String>();
 

--- a/src/main/java/org/concordion/integration/junit4/JUnit4FrameworkProvider.java
+++ b/src/main/java/org/concordion/integration/junit4/JUnit4FrameworkProvider.java
@@ -7,6 +7,6 @@ public class JUnit4FrameworkProvider implements TestFrameworkProvider {
     @Override
     public boolean isConcordionFixture(Class<?> clazz) {
         RunWith annotation = clazz.getAnnotation(RunWith.class);
-        return annotation != null && ConcordionRunner.class.equals(annotation.value());
+        return annotation != null && ConcordionRunner.class.isAssignableFrom(annotation.value());
     }
 }

--- a/src/main/java/org/concordion/internal/FixtureRunner.java
+++ b/src/main/java/org/concordion/internal/FixtureRunner.java
@@ -3,6 +3,7 @@ package org.concordion.internal;
 import org.concordion.Concordion;
 import org.concordion.api.Fixture;
 import org.concordion.api.ResultSummary;
+import org.concordion.api.SpecificationLocator;
 import org.concordion.internal.cache.RunResultsCache;
 import org.concordion.internal.extension.FixtureExtensionLoader;
 
@@ -12,8 +13,8 @@ public class FixtureRunner {
     private static RunResultsCache runResultsCache = RunResultsCache.SINGLETON;
     private Concordion concordion;
 
-    public FixtureRunner(Fixture fixture) throws UnableToBuildConcordionException {
-        ConcordionBuilder concordionBuilder = new ConcordionBuilder().withFixture(fixture);
+    public FixtureRunner(Fixture fixture, SpecificationLocator specificationLocator) throws UnableToBuildConcordionException {
+        ConcordionBuilder concordionBuilder = new ConcordionBuilder().withFixture(fixture).withSpecificationLocator(specificationLocator);
         new FixtureExtensionLoader().addExtensions(fixture, concordionBuilder);
         new FixtureOptionsLoader().addOptions(fixture, concordionBuilder);
         concordion = concordionBuilder.build();


### PR DESCRIPTION
WIP: This pull request relates to #249. It demonstrates the idea on how third party frameworks could hook into Concordion and also provide their own SpecificationLocator implementations. The given implementation might be incomplete; it is however the less invasive option to show the idea behind.