### PR TITLE
Remove openjdk6 and change JDK7 to openjdk7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,4 @@ addons:
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk6
+  - openjdk7


### PR DESCRIPTION
Since oraclejdk7 is no longer supported - https://github.com/travis-ci/travis-ci/issues/7884.
It appears that openjdk6 is not supported either.