### PR TITLE
Fix thread-safety issue in FixtureSpecificationMapper.

### DIFF
--- a/src/main/java/org/concordion/internal/FixtureSpecificationMapper.java
+++ b/src/main/java/org/concordion/internal/FixtureSpecificationMapper.java
@@ -18,7 +18,12 @@ import java.util.ServiceLoader;
  */
 public class FixtureSpecificationMapper {
 
-    private static ServiceLoader<TestFrameworkProvider> serviceLoader = ServiceLoader.load(TestFrameworkProvider.class);
+    private static ThreadLocal serviceLoaderHolder  = new ThreadLocal<ServiceLoader<TestFrameworkProvider>>() {
+        @Override
+        protected ServiceLoader<TestFrameworkProvider> initialValue() {
+            return ServiceLoader.load(TestFrameworkProvider.class);
+        }
+    };
 
     public static Resource toSpecificationResource(Object fixture, String specificationSuffix) {
         String slashedClassName = fixture.getClass().getName().replaceAll("\\.", "/");
@@ -49,6 +54,7 @@ public class FixtureSpecificationMapper {
     private static Class<?> getFixtureClass(String name) throws ClassNotFoundException {
         try {
             Class<?> clazz = Class.forName(name);
+            ServiceLoader<TestFrameworkProvider> serviceLoader = (ServiceLoader<TestFrameworkProvider>) serviceLoaderHolder.get();
             Iterator<TestFrameworkProvider> iterator = serviceLoader.iterator();
             while (iterator.hasNext()) {
                 TestFrameworkProvider provider = iterator.next();


### PR DESCRIPTION
From https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html, instances of this class are not safe for use by multiple concurrent threads.
This fix wraps the ServiceLoader instance in a ThreadLocal so we have one ServiceLoader per thread.
Fixes #259.