### PR TITLE
Issue 313 access table data in a map

### DIFF
--- a/src/main/java/org/concordion/internal/SimpleEvaluator.java
+++ b/src/main/java/org/concordion/internal/SimpleEvaluator.java
@@ -37,7 +37,7 @@ public class SimpleEvaluator extends OgnlEvaluator {
     private static final String PROPERTY_NAME_PATTERN = "[a-z][a-zA-Z0-9_]*";
     private static final String STRING_PATTERN = "'[^']+'";
     private static final String LHS_VARIABLE_PATTERN = "#" + METHOD_NAME_PATTERN;
-    private static final String RHS_VARIABLE_PATTERN = "(" + LHS_VARIABLE_PATTERN + "|#TEXT|#HREF|#LEVEL)";
+    private static final String RHS_VARIABLE_PATTERN = "(" + LHS_VARIABLE_PATTERN + "|#TEXT|#HREF|#LEVEL|#ROW)";
     private static final String METHOD_CALL_PARAMS = METHOD_NAME_PATTERN + " *\\( *" + RHS_VARIABLE_PATTERN + "(, *" + RHS_VARIABLE_PATTERN + " *)*\\)";
     private static final String METHOD_CALL_NO_PARAMS = METHOD_NAME_PATTERN + " *\\( *\\)";
     private static final String TERNARY_STRING_RESULT = " \\? " + STRING_PATTERN + " : " + STRING_PATTERN;

--- a/src/main/java/org/concordion/internal/command/executeCommand/modificationStrategies/ExecuteCommandTableModification.java
+++ b/src/main/java/org/concordion/internal/command/executeCommand/modificationStrategies/ExecuteCommandTableModification.java
@@ -14,6 +14,7 @@ import java.util.Map;
  * Created by tim on 30/10/16.
  */
 public class ExecuteCommandTableModification extends ExecuteCommandModification {
+    private static final String ROW_VARIABLE = "#ROW";
 
     private Map<Integer, CommandCall> populateCommandCallByColumnMap(Table table, CommandCall tableCommandCall) {
         Map<Integer, CommandCall> commandCallByColumn = new HashMap<Integer, CommandCall>();
@@ -58,6 +59,7 @@ public class ExecuteCommandTableModification extends ExecuteCommandModification 
             }
 
             CommandCall rowCommand = duplicateCommandForDifferentElement(commandCall, row.getElement());
+            rowCommand.setConstantForExecution(ROW_VARIABLE, getRowMap(row, table));
 
             for (int cellCount = 0; cellCount < cells.length; cellCount++) {
                 CommandCall headerCall = headerCommands.get(cellCount);
@@ -76,5 +78,15 @@ public class ExecuteCommandTableModification extends ExecuteCommandModification 
         for (CommandCall call : headerCommands.values()) {
             call.transferToParent(null);
         }
+    }
+
+    private Map<String, String> getRowMap(Row row, Table table) {
+        Map<String, String> rowMap = new HashMap<>();
+        Element[] cells = row.getCells();
+        Element[] headerCells = table.getLastHeaderRow().getCells();
+        for (int i = 0; i<Math.min(cells.length, headerCells.length); i++) {
+            rowMap.put(headerCells[i].getText().trim(), cells[i].getText().trim());
+        }
+        return rowMap;
     }
 }

--- a/src/test/java/spec/concordion/common/command/execute/ExecutingTablesTest.java
+++ b/src/test/java/spec/concordion/common/command/execute/ExecutingTablesTest.java
@@ -1,5 +1,6 @@
 package spec.concordion.common.command.execute;
 
+import org.concordion.api.FullOGNL;
 import org.concordion.api.listener.AssertFailureEvent;
 import org.concordion.integration.junit4.ConcordionRunner;
 import org.junit.runner.RunWith;
@@ -7,8 +8,15 @@ import org.junit.runner.RunWith;
 import test.concordion.ProcessingResult;
 import test.concordion.TestRig;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 @RunWith(ConcordionRunner.class)
+@FullOGNL
 public class ExecutingTablesTest {
+    private List<Map<String, String>> rows = new ArrayList<>();
 
     public Result process(String fragment) throws Exception {
         
@@ -32,6 +40,20 @@ public class ExecutingTablesTest {
     
     public String generateUsername(String fullName) {
         return fullName.replaceAll(" ", "").toLowerCase();
+    }
+
+    public String processRow(Map<String, String> row) {
+        System.out.println(row);
+        rows.add(row);
+        return generateUsername(row.get("First Name") + " " + row.get("Last Name"));
+    }
+
+    public List<Map<String, String>> getLoggedRows() {
+        return rows;
+    }
+
+    public void resetRowMap() {
+        rows = new ArrayList<>();
     }
 
     class Result {

--- a/src/test/resources/spec/concordion/common/command/execute/ExecutingTables.html
+++ b/src/test/resources/spec/concordion/common/command/execute/ExecutingTables.html
@@ -56,12 +56,172 @@
 
     </div>
 
-    <h2>Further Details</h2>
+    <h2>Getting the content from each row</h2>
 
-    <ul>
-        <li><a href="TODO.html">TODO: Are <code>&lt;thead&gt;</code> and <code>&lt;tbody&gt;</code> supported?</a></li>
-    </ul>
+    <p concordion:execute="resetRowMap()">
+        On occasions where the whole table row is required, for example logging the row,
+        the special variable <code>#ROW</code> contains a <code>Map&lt;String, String&gt;</code>
+        with the key being the column header value and the value being the column cell value
+        for each column in the table row.
+    </p>
 
+    <div class="example">
+
+        <h3>Example</h3>
+
+        <pre concordion:set="#result = process(#TEXT)">
+&lt;table concordion:execute="#username = processRow(#ROW)"&gt;
+    &lt;tr&gt;
+        &lt;th>First Name&lt;/th&gt;
+        &lt;th>Last Name&lt;/th&gt;
+        &lt;th concordion:assertEquals="#username"&gt;Username&lt;/th&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+        &lt;td&gt;Jacinda&lt;/td&gt;
+        &lt;td&gt;Ardern&lt;/td&gt;
+        &lt;td&gt;jacindaardern&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+        &lt;td&gt;Judith&lt;/td&gt;
+        &lt;td&gt;Collins&lt;/td&gt;
+        &lt;td&gt;judithcollins&lt;/td&gt;
+    &lt;/tr&gt;
+&lt;/table&gt;
+</pre>
+
+        <p>
+            The <code>processRow(#ROW)</code> method is called once for each row, being passed a <code>Map</code> with the entries:
+        </p>
+<table concordion:verify-rows="#row : getLoggedRows()">
+    <tr>
+        <th concordion:assert-equals='#row.get("First Name")'>First Name</th>
+        <th concordion:assert-equals='#row.get("Last Name")'>Last Name</th>
+        <th concordion:assert-equals='#row.get("Username")'>Username</th>
+    </tr>
+    <tr>
+        <td>Jacinda</td>
+        <td>Ardern</td>
+        <td>jacindaardern</td>
+    </tr>
+    <tr>
+        <td>Judith</td>
+        <td>Collins</td>
+        <td>judithcollins</td>
+    </tr>
+</table>
+
+    </div>
+
+    <h3>Special cases</h3>
+
+    <h4>Duplicate headers</h4>
+
+    <p concordion:execute="resetRowMap()">
+        If there are multiple columns with the same header text,
+        the map will contain one entry for the last column with that header
+        (that is, the last entry with that header will overwrite all previous entries).
+    </p>
+
+    <div class="example">
+
+        <h3>Example</h3>
+
+        <pre concordion:set="#result = process(#TEXT)">
+&lt;table concordion:execute="#username = processRow(#ROW)"&gt;
+    &lt;tr&gt;
+        &lt;th>First Name&lt;/th&gt;
+        &lt;th>First Name&lt;/th&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+        &lt;td&gt;Noel&lt;/td&gt;
+        &lt;td&gt;Nicky&lt;/td&gt;
+    &lt;/tr&gt;
+&lt;/table&gt;
+</pre>
+
+        <p>
+            The <code>#ROW</code> map contains a single entry with data from the last <code>First Name</code> column:
+        </p>
+        <table concordion:verify-rows="#row : getLoggedRows()">
+            <tr>
+                <th concordion:assert-equals='#row.get("First Name")'>First Name</th>
+            </tr>
+            <tr>
+                <td>Nicky</td>
+            </tr>
+        </table>
+
+    </div>
+
+    <h4>Empty headers</h4>
+
+    <p concordion:execute="resetRowMap()">
+        The key for a column with an empty header is an empty string <code>""</code>.
+    </p>
+
+    <div class="example">
+
+        <h3>Example</h3>
+
+        <pre concordion:set="#result = process(#TEXT)">
+&lt;table concordion:execute="#username = processRow(#ROW)"&gt;
+    &lt;tr&gt;
+        &lt;th>&lt;/th&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+        &lt;td&gt;Tūī&lt;/td&gt;
+    &lt;/tr&gt;
+&lt;/table&gt;
+</pre>
+
+        <p>
+            The <code>#ROW</code> map contains a single entry with the empty string <code>""</code> as its key:
+        </p>
+        <table concordion:verify-rows="#row : getLoggedRows()">
+            <tr>
+                <th concordion:assert-equals='#row.get("")'></th>
+            </tr>
+            <tr>
+                <td>Tūī</td>
+            </tr>
+        </table>
+
+    </div>
+
+        <h4>HTML entities in column header</h4>
+
+        <p concordion:execute="resetRowMap()">
+            HTML entities in column headers are decoded into their corresponding characters.
+        </p>
+
+        <div class="example">
+
+            <h3>Example</h3>
+
+            <pre concordion:set="#result = process(#TEXT)">
+&lt;table concordion:execute="#username = processRow(#ROW)"&gt;
+    &lt;tr&gt;
+        &lt;th>&amp;gt; β&lt;/th&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+        &lt;td&gt;X &amp;amp; Y&lt;/td&gt;
+    &lt;/tr&gt;
+&lt;/table&gt;
+</pre>
+
+            <p>
+                The <code>#ROW</code> map contains the single entry:
+            </p>
+            <table concordion:verify-rows="#row : getLoggedRows()">
+                <tr>
+                    <th concordion:assert-equals='#row.get("&gt; β")'>&gt; β</th>
+                </tr>
+                <tr>
+                    <td>X &amp; Y</td>
+                </tr>
+            </table>
+
+        </div>
 
 </body>
 </html>


### PR DESCRIPTION
Implemented a special variable `#ROW` which is populated when the `execute` command runs on a `<table>` element. When each row of the table is executed the variable contains a map of the row cells, with the header cell contents as the key and the row cell contents as the value.

Fixes #313 and fixes #316.