### PR TITLE
#285 workaround to skip resources that cannot be loaded as File

### DIFF
--- a/src/main/java/org/concordion/internal/FixtureType.java
+++ b/src/main/java/org/concordion/internal/FixtureType.java
@@ -111,7 +111,7 @@ public class FixtureType implements FixtureDeclarations {
                     rootPaths.add(new File(uri));
                 } catch (IllegalArgumentException e) {
                   if (e.getMessage().equals("URI is not hierarchical")) {
-                      LOG.log(Level.INFO, String.format("Skipping resource %s: Java 8 or > detected", uri), e);
+                      LOG.log(Level.FINER, String.format("Skipping resource %s: Java 8 or > detected", uri), e);
                       continue;
                   }
                   throw e;

--- a/src/main/java/org/concordion/internal/FixtureType.java
+++ b/src/main/java/org/concordion/internal/FixtureType.java
@@ -18,6 +18,8 @@ import java.util.logging.Logger;
 
 public class FixtureType implements FixtureDeclarations {
     private static final Logger LOG = Logger.getLogger(FixtureType.class.getSimpleName());
+    private static final String IGNORE_EXCEPTION_MESSAGE = "URI is not hierarchical";
+
     private Class<?> fixtureClass;
     private ArrayList<Class<?>> classHierarchyParentFirst;
 
@@ -110,7 +112,8 @@ public class FixtureType implements FixtureDeclarations {
                 try {
                     rootPaths.add(new File(uri));
                 } catch (IllegalArgumentException e) {
-                  if (e.getMessage().equals("URI is not hierarchical")) {
+                    // TODO seek cleaner solution than ignoring exceptions when implementing resources in jar files #278
+                  if (IGNORE_EXCEPTION_MESSAGE.equals(e.getMessage())) {
                       LOG.log(Level.FINER, String.format("Skipping resource %s: Java 8 or > detected", uri), e);
                       continue;
                   }


### PR DESCRIPTION
Related to the issue #285, I've made a fix to skip the jars that cannot be loaded due to an error that only happens in Java 9 or later versions when external resources are added to the fixture:
```
@ConcordionResources({
	"/_concordion/resources/header.png",
	"/_concordion/resources/concordion.css"
})
public abstract class AbstractFixture {
//...
}
```
This is a workaround solution using the best effort strategy. As for most of the projects using Concordion, we only load resources that lies within the same project structure, so it's quite unusual to load resources from external libraries.
Feel free to improve the code as youse want, but the way as is now, it should help a lot of legacy projects using newer java versions.