### PR TITLE
Fix git-publish plugin version not found

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'net.nemerosa.versioning' version '2.14.0'
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
     id 'net.researchgate.release' version '2.8.1'
-    id 'org.ajoberstar.git-publish' version '3.0.0'
+    id 'org.ajoberstar.git-publish' version '3.0.1'
 }
 
 description = 'Concordion is an open source framework for Java that lets you turn a plain English description of a requirement into an automated test'


### PR DESCRIPTION
Version 3.0.0 not found since JCenter was deprecated in 2021