### PR TITLE
Update to JUnit 5 and use JUnit Vintage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 ext {
+    junitJupiterVersion = '5.8.2'
     flexmarkVersion = '0.62.2'
     githubUrl = "https://github.com/concordion/${project.name}"
     issuesUrl = "${githubUrl}/issues"
@@ -34,8 +35,14 @@ ext {
 }
 
 dependencies {
-    api 'junit:junit:4.13.2',
-            "com.vladsch.flexmark:flexmark:$flexmarkVersion",
+    api (platform("org.junit:junit-bom:$junitJupiterVersion"))
+    api 'org.junit.jupiter:junit-jupiter'
+    api 'junit:junit:4.13.2'
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
+
+    api "com.vladsch.flexmark:flexmark:$flexmarkVersion",
             "com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:$flexmarkVersion",
             "com.vladsch.flexmark:flexmark-ext-tables:$flexmarkVersion"
 
@@ -78,6 +85,7 @@ targetCompatibility = 8
 
 test {
     systemProperties['concordion.output.dir'] = "${reporting.baseDir}"
+    useJUnitPlatform()
 }
 
 compileTestJava.dependsOn compileTestDummiesJava
@@ -163,6 +171,11 @@ publishing {
                     }
                     developer {
                         id = 'wangyizhuo'
+                        roles = ['Developer']
+                    }
+                    developer {
+                        id = 'lorenzodee'
+                        name = 'Lorenzo Dee'
                         roles = ['Developer']
                     }
                 }

--- a/src/main/java/org/concordion/internal/ConcordionBuilder.java
+++ b/src/main/java/org/concordion/internal/ConcordionBuilder.java
@@ -416,8 +416,8 @@ public class ConcordionBuilder implements ConcordionExtender {
         return this;
     }
 
-    public ConcordionBuilder withFixture(Fixture fixture) {
-        this.fixtureType = fixture.getFixtureType();
+    public ConcordionBuilder withFixtureType(FixtureType fixtureType) {
+        this.fixtureType = fixtureType;
 
         withResources(fixtureType);
 
@@ -427,6 +427,13 @@ public class ConcordionBuilder implements ConcordionExtender {
         if (fixtureType.declaresFullOGNL()) {
             withEvaluatorFactory(new OgnlEvaluatorFactory());
         }
+
+        return this;
+    }
+
+    public ConcordionBuilder withFixture(Fixture fixture) {
+        withFixtureType(fixture.getFixtureType());
+
         flexmarkOptions = new FlexmarkOptionsLoader().getFlexmarkOptionsForFixture(fixture);
         if (flexmarkOptions != null) {
             configureWith(flexmarkOptions);

--- a/src/main/java/org/concordion/internal/ResourceFinder.java
+++ b/src/main/java/org/concordion/internal/ResourceFinder.java
@@ -3,6 +3,7 @@ package org.concordion.internal;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.lang.annotation.Annotation;
+import java.nio.file.InvalidPathException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -125,7 +126,11 @@ public class ResourceFinder {
             search = new File(root, packageName);
             search = new File(search, sourceFile);
         }
-        return search.toPath().normalize().toFile();
+        try {
+            return search.toPath().normalize().toFile();
+        } catch (InvalidPathException e) {
+            return search; // as fallback
+        }
     }
 
     private boolean isSearchRoot(String sourceFile) {

--- a/src/main/java/org/concordion/internal/extension/FixtureExtensionLoader.java
+++ b/src/main/java/org/concordion/internal/extension/FixtureExtensionLoader.java
@@ -12,25 +12,42 @@ import org.concordion.api.extension.ConcordionExtensionFactory;
 import org.concordion.api.extension.Extension;
 import org.concordion.api.extension.Extensions;
 import org.concordion.internal.ConcordionBuilder;
+import org.concordion.internal.FixtureType;
 import org.concordion.internal.util.SimpleFormatter;
 
 public class FixtureExtensionLoader {
-    
+
     public void addExtensions(Fixture fixture, ConcordionBuilder concordionBuilder) {
         for (ConcordionExtension concordionExtension : getExtensionsForFixture(fixture)) {
             concordionExtension.addTo(concordionBuilder);
         }
     }
 
+    public void addExtensions(FixtureType fixtureType, ConcordionBuilder concordionBuilder) {
+        for (ConcordionExtension concordionExtension : getExtensionsForFixtureType(fixtureType)) {
+            concordionExtension.addTo(concordionBuilder);
+        }
+    }
+
     public List<ConcordionExtension> getExtensionsForFixture(Fixture fixture) {
-        final List<ConcordionExtension> extensions = new ArrayList<ConcordionExtension>();
+        final List<ConcordionExtension> extensions = getExtensionsForFixtureType(fixture.getFixtureType());
 
         List<Class<?>> classes = fixture.getFixtureType().getClassHierarchyParentFirst();
         for (Class<?> class1 : classes) {
-            extensions.addAll(getExtensionsFromClassAnnotation(class1));
             extensions.addAll(getExtensionsFromAnnotatedFields(fixture, class1));
         }
-        
+
+        return extensions;
+    }
+
+    public List<ConcordionExtension> getExtensionsForFixtureType(FixtureType fixtureType) {
+        final List<ConcordionExtension> extensions = new ArrayList<ConcordionExtension>();
+
+        List<Class<?>> classes = fixtureType.getClassHierarchyParentFirst();
+        for (Class<?> class1 : classes) {
+            extensions.addAll(getExtensionsFromClassAnnotation(class1));
+        }
+
         return extensions;
     }
 


### PR DESCRIPTION
- Specs were failing with JUnit Vintage because the `ConcordionRunner` was instantiating the fixture object too soon in its constructor. After modifying the `ConcordionRunner`, the specs (as-is, without changes) are now working on JUnit 4 and JUnit Vintage.
- Also fixed `ResourceFinder` which was failing on Windows